### PR TITLE
Fix the NPE thrown when deactivating a tenant

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/org/wso2/carbon/tenant/mgt/ui/i18n/Resources.properties
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/org/wso2/carbon/tenant/mgt/ui/i18n/Resources.properties
@@ -44,6 +44,7 @@ self.registration=Registry Tenant
 gaas=GaaS
 gaas.register.a.new.tenant=Register A New Tenant
 active=Active
+actions=Actions
 theme.management=Theme Management
 word.verification=Word Verification
 captcha.message=Type the characters you see in the picture below.

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/activate_tenant_ajaxprocessor.jsp
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/activate_tenant_ajaxprocessor.jsp
@@ -37,17 +37,17 @@
 
     String error = "Error in updating the tenant activation status.";
     String tenantDomain = "";
-    Boolean activated = (Boolean)session.getAttribute("isActivatedTenant");
 
     TenantServiceClient serviceClient = new TenantServiceClient(config, session);
-
     try {
-        tenantDomain = request.getParameter("activatingDomain");
+        tenantDomain = request.getParameter("tenant.domain");
+        String activateStr = request.getParameter("activate");
+        Boolean activate = activateStr == null ? null : Boolean.valueOf(activateStr);
 
-        if(activated){
-            serviceClient.deactivateTenant(tenantDomain);
-        } else if (!activated){
+        if (activate != null && activate){
             serviceClient.activateTenant(tenantDomain);
+        } else if (activate != null && !activate){
+            serviceClient.deactivateTenant(tenantDomain);
         }
 
         response.sendRedirect("../tenant-mgt/view_tenants.jsp");

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/add_tenant.jsp
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/add_tenant.jsp
@@ -88,11 +88,11 @@ String domainName = request.getParameter("domain");
     String isCloudDeployment =  ServerConfiguration.getInstance().getFirstProperty("IsCloudDeployment");
     String enableEmailUserName =  ServerConfiguration.getInstance().getFirstProperty("EnableEmailUserName");
     boolean isEmailUserNameEnabled = false;
-    
+
     if (enableEmailUserName != null && enableEmailUserName.equalsIgnoreCase("true")){
     	isEmailUserNameEnabled = true;
     }
-    
+
     String email = "";
     if (domainName != null && !domainName.equals("")) {
         try {
@@ -373,8 +373,8 @@ String domainName = request.getParameter("domain");
                 <% } else { %> value="<fmt:message key="activate.account.btn"/>" <% } %>/>
             </td>
 
-            <input type="hidden" name="activatingDomain" id="activatingDomain" value="<%=Encode.forHtml(domainName)%>"/>
-
+            <input type="hidden" name="tenant.domain" id="tenant.domain" value="<%=Encode.forHtml(domainName)%>"/>
+            <input type="hidden" name="activate" value="<%=!isActive%>"/>
         </tr>
         </tbody>
     </table>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/js/tenant_config.js
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/js/tenant_config.js
@@ -1,5 +1,5 @@
 function addTenant(isUpdating, isPublicCloud, isEmailUser) {
-    
+
     var reason = "";
     var addTenantForm = document.getElementById('addTenantForm');
     var adminPassword = document.getElementById('admin-password');
@@ -35,7 +35,7 @@ function addTenant(isUpdating, isPublicCloud, isEmailUser) {
     else {
         var domain = document.getElementById('domain');
         var adminName = document.getElementById('admin');
-        
+
         if (isEmailUser) {
         	email = adminName;
         }
@@ -113,32 +113,11 @@ function showSuccessUpdateMessage() {
     CARBON.showInfoDialog(message);
     return;
 }
-function activationChanged(cbox, domain) {
-    if (!cbox.checked) {
-        CARBON.showConfirmationDialog("Are you sure you want to deactivate the domain: " +
-                domain + ".", function() {
-            changeTenentActivation(domain);
-        }, function() {
-            cbox.checked = "on";
-        });
-    } else {
-        changeTenentActivation(domain);
-    }
-
-}
-
-function changeTenentActivation (domain){
-    jQuery.ajax({
-        type: "POST",
-        url: "activate_tenant_ajaxprocessor.jsp",
-        headers: {
-            Accept: "text/html"
-        },
-        data: {
-            "activatingDomain": domain
-        },
-        async: false
-    });
+function activationChanged(btn, domain) {
+    CARBON.showConfirmationDialog("Are you sure you want to " + btn.id +
+            " the domain: " + domain + "?", function() {
+        document.forms[domain + '_form'].submit();
+    }, function() { });
 }
 
 function fillAdminValue() {
@@ -218,7 +197,7 @@ function domainAvailability(domain) {
              error = "Error in checking domain availability";
 
         },
-        async: false        
+        async: false
     });
 
     return error;

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/view_tenants.jsp
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/view_tenants.jsp
@@ -116,7 +116,7 @@
                 } else {
                 	   tenantsInfo = client.retrievePaginatedTenants(pageNumber);
                 }
-             
+
 
                 tenantInfoArr = tenantsInfo.getTenantInfoBeans();
                 numberOfPages = tenantsInfo.getNumberOfPages();
@@ -163,7 +163,7 @@
                                 key="admin.email"/></th>
                         <th style="padding-left:5px;text-align:left;"><fmt:message
                                 key="created.date"/></th>
-                        <th style="padding-left:5px;text-align:left;"><fmt:message key="active"/></th>
+                        <th style="padding-left:5px;text-align:left;"><fmt:message key="actions"/></th>
                         <th style="padding-left:5px;text-align:left;"><fmt:message key="edit"/></th>
                     </tr>
                     </thead>
@@ -191,11 +191,19 @@
                     <td style="padding-left:5px;padding-top:3px;text-align:left;"><%=createdDateStr%>
                     </td>
                     <td style="padding-left:5px;padding-top:3px;text-align:left;">
-                        <form id="<%=tenantDomain%>_form" action="view_tenants.jsp" method="post">
-                            <input type="checkbox" name="activate"
-                                   onchange="javascript:activationChanged(this, '<%=tenantDomain%>')"
-                                   <%if (isActive) {%>checked="true"<%}%>/>
-                            <input type="hidden" name="activate.domain" value="<%=tenantDomain%>"/>
+                        <form id="<%=tenantDomain%>_form" action="activate_tenant_ajaxprocessor.jsp" method="post">
+                            <% if (isActive) { %>
+                              <input type="button" id="deactivate"
+                                     onclick="activationChanged(this, '<%=tenantDomain%>'); return false;"
+                                     value="Deactivate" />
+                            <% } else { %>
+                              <input type="button" id="activate"
+                                     onclick="activationChanged(this, '<%=tenantDomain%>'); return false;"
+                                     value="Activate" />
+                            <% } %>
+
+                            <input type="hidden" name="tenant.domain" value="<%=tenantDomain%>"/>
+                            <input type="hidden" name="activate" value="<%=!isActive%>"/>
                         </form>
                     </td>
                     <td style="padding-left:5px;padding-top:3px;text-align:left;"><a

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2008, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -109,6 +109,9 @@ public class TenantMgtAdminService extends AbstractAdmin {
 
         // For the super tenant tenant creation, tenants are always activated as they are created.
         TenantMgtUtil.activateTenantInitially(tenantInfoBean, tenantId);
+        log.info("Added the tenant '" + tenantDomain + " [" + tenantId +
+            "]' by '" + PrivilegedCarbonContext.getThreadLocalCarbonContext().
+            getUsername() + "'");
 
         return TenantMgtUtil.prepareStringToShowThemeMgtPage(tenant.getId());
     }
@@ -211,7 +214,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
         }
         return tenantList;
     }
-    
+
     /**
      * Get the list of the tenants
      *
@@ -248,7 +251,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
         List<TenantInfoBean> tenantList = getAllTenants();
         return tenantList.toArray(new TenantInfoBean[tenantList.size()]);
     }
-    
+
     /**
      * Retrieve all the tenants which matches the partial search domain
      *
@@ -275,7 +278,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
         DataPaginator.doPaging(pageNumber, tenantList, paginatedTenantInfoBean);
         return paginatedTenantInfoBean;
     }
-    
+
     /**
      * Method to retrieve all the tenants paginated
      *
@@ -468,7 +471,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
             log.error(msg, e);
             throw new Exception(msg, e);
         }
-        
+
         //Notify tenant update to all listeners
         try {
             TenantMgtUtil.triggerUpdateTenant(tenantInfoBean);
@@ -478,6 +481,9 @@ public class TenantMgtAdminService extends AbstractAdmin {
             throw new Exception(msg, e);
         }
 
+        log.info("Updated the tenant '" + tenantDomain + " [" + tenantId +
+            "]' by '" + PrivilegedCarbonContext.getThreadLocalCarbonContext().
+            getUsername() + "'");
         //updating the usage plan
         /*try{
             if(TenantMgtServiceComponent.getBillingService() != null){
@@ -520,6 +526,9 @@ public class TenantMgtAdminService extends AbstractAdmin {
             throw new Exception(msg, e);
         }
 
+        log.info("Activated the tenant '" + tenantDomain + " [" + tenantId +
+            "]' by '" + PrivilegedCarbonContext.getThreadLocalCarbonContext().
+            getUsername() + "'");
     }
 
     /**
@@ -551,6 +560,10 @@ public class TenantMgtAdminService extends AbstractAdmin {
             log.error(msg, e);
             throw new Exception(msg, e);
         }
+
+        log.info("Deactivated the tenant '" + tenantDomain + " [" + tenantId +
+            "]' by '" + PrivilegedCarbonContext.getThreadLocalCarbonContext().
+            getUsername() + "'");
     }
 
     /**


### PR DESCRIPTION
Step to re-prod:

1. Create a tenant
2. Logout and Log-in again.
3. Now, click on the deactivate checkbox in the view_tenants.jsp.
4. Check the logs.

```
java.lang.NullPointerException
	at org.apache.jsp.tenant_002dmgt.activate_005ftenant_005fajaxprocessor_jsp._jspService(activate_005ftenant_005fajaxprocessor_jsp.java:134)
	at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:70)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:439)
	at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:395)
	at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:339)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
	at org.wso2.carbon.ui.JspServlet.service(JspServlet.java:155)
	at org.wso2.carbon.ui.TilesJspServlet.service(TilesJspServlet.java:80)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
	at org.eclipse.equinox.http.helper.ContextPathServletAdaptor.service(ContextPathServletAdaptor.java:37)
	at org.eclipse.equinox.http.servlet.internal.ServletRegistration.service(ServletRegistration.java:61)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.processAlias(ProxyServlet.java:128)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.service(ProxyServlet.java:68)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
	at org.wso2.carbon.tomcat.ext.servlet.DelegationServlet.service(DelegationServlet.java:68)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:120)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.wso2.carbon.tomcat.ext.filter.CharacterSetFilter.doFilter(CharacterSetFilter.java:61)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:120)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:218)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:122)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:505)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:169)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.CarbonTomcatValve$1.invoke(CarbonTomcatValve.java:47)
	at org.wso2.carbon.webapp.mgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:57)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:47)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:159)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:956)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:442)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1082)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:623)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1756)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1715)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:745)
```

Resolves #127 