### PR TITLE
Fix tenant deletion

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -583,7 +583,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
 
                 String tenantDelete = TenantMgtServiceComponent.getServerConfigurationService().getFirstProperty("TenantDelete");
 
-                if ((tenantDelete == null)
+                if ((tenantDelete != null)
                     && (tenantDelete.equals("true"))) {
                     log.info("Tenant Delete Flag is True");
                     if (TenantMgtServiceComponent.getBillingService() != null) {


### PR DESCRIPTION
There are multiple problems with the current tenant deletion code:
- Invalid condition to check if the TenantDelete parameter is set that result in a NullPointerException if the value is not set in carbon.xml (which is not documented)
- Cleanup of the tenant database tables fails because of faulty code to initialise the database connection
- The code always try to notify all cluster nodes of tenant deletion, even if there's no cluster configuration, wich result in a NullPointerException
