### PR TITLE
Disable proxy access with wrong URLs in tenant mode

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.dispatcher/src/main/java/org/wso2/carbon/tenant/dispatcher/MultitenantDispatcher.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.dispatcher/src/main/java/org/wso2/carbon/tenant/dispatcher/MultitenantDispatcher.java
@@ -46,10 +46,12 @@ public class MultitenantDispatcher extends AbstractDispatcher {
         if (service == null) {
             String to = mc.getTo().getAddress();
 
-            int tenantDelimiterIndex = to.indexOf("/t/");
-            if (tenantDelimiterIndex != -1) {
-                AxisConfiguration ac = mc.getConfigurationContext().getAxisConfiguration();
-                return ac.getService(MultitenantConstants.MULTITENANT_DISPATCHER_SERVICE);
+            if (to.startsWith(mc.getConfigurationContext().getServiceContextPath())) {
+                int tenantDelimiterIndex = to.indexOf("/t/");
+                if (tenantDelimiterIndex != -1) {
+                    AxisConfiguration ac = mc.getConfigurationContext().getAxisConfiguration();
+                    return ac.getService(MultitenantConstants.MULTITENANT_DISPATCHER_SERVICE);
+                }
             }
         }
         return service;


### PR DESCRIPTION
## Purpose
> Solving the issue where in the tenant mode, proxy services being accessed through incorrect URLs like 'http://localhost:8280/<anyString>/t/testtenant.com/Proxy1'.
Resolves https://wso2.org/jira/browse/ESBJAVA-3992

## Approach
> Made sure that the 'to' address in the message context is starting with the service context path. 