### PR TITLE
Fix issue with accessing tenant rest api url

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.dispatcher/src/main/java/org/wso2/carbon/tenant/dispatcher/MultitenantDispatcher.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.dispatcher/src/main/java/org/wso2/carbon/tenant/dispatcher/MultitenantDispatcher.java
@@ -34,6 +34,7 @@ import javax.xml.namespace.QName;
 public class MultitenantDispatcher extends AbstractDispatcher {
 
     public static final String NAME = "MultitenantDispatcher";
+    private static final String TENANT_PATH = "/t/";
 
     public void initDispatcher() {
         QName qn = new QName("http://wso2.org/projects/carbon", NAME);
@@ -47,14 +48,20 @@ public class MultitenantDispatcher extends AbstractDispatcher {
             String to = mc.getTo().getAddress();
 
             if (to.startsWith(mc.getConfigurationContext().getServiceContextPath())) {
-                int tenantDelimiterIndex = to.indexOf("/t/");
+                int tenantDelimiterIndex = to.indexOf(TENANT_PATH);
                 if (tenantDelimiterIndex != -1) {
-                    AxisConfiguration ac = mc.getConfigurationContext().getAxisConfiguration();
-                    return ac.getService(MultitenantConstants.MULTITENANT_DISPATCHER_SERVICE);
+                    getService(mc);
                 }
+            } else if (to.startsWith(TENANT_PATH)) {
+                getService(mc);
             }
         }
         return service;
+    }
+
+    private static AxisService getService(MessageContext mc) throws AxisFault {
+        AxisConfiguration ac = mc.getConfigurationContext().getAxisConfiguration();
+        return ac.getService(MultitenantConstants.MULTITENANT_DISPATCHER_SERVICE);
     }
 
     public AxisOperation findOperation(AxisService svc, MessageContext mc) throws AxisFault {


### PR DESCRIPTION
## Purpose
> Rest APIs in the tenant could not be accessed because of the fix introduced for https://wso2.org/jira/browse/ESBJAVA-3992. This PR fixes that. Now the tenant services cannot be accessed by wrong URLs as well as the tenant rest APIs can be accessed.

