### PR TITLE
Improve tenant deletion

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -586,8 +586,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                 // <TenantDelete>true</TenantDelete> with in <server> tag.
                 String tenantDelete = TenantMgtServiceComponent.getServerConfigurationService()
                         .getFirstProperty("TenantDelete");
-                if ((tenantDelete != null)
-                    && (tenantDelete.equals("true"))) {
+                if ("true".equals(tenantDelete)) {
                     log.info("Tenant Delete Flag is True");
                     if (TenantMgtServiceComponent.getBillingService() != null) {
                         TenantMgtServiceComponent.getBillingService().deleteBillingData(tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -575,7 +575,6 @@ public class TenantMgtAdminService extends AbstractAdmin {
      * @param tenantDomain The domain name of the tenant that needs to be deleted
      */
     public void deleteTenant(String tenantDomain) throws StratosException, org.wso2.carbon.user.api.UserStoreException {
-
         TenantManager tenantManager = TenantMgtServiceComponent.getTenantManager();
         if (tenantManager != null) {
             int tenantId = tenantManager.getTenantId(tenantDomain);
@@ -634,7 +633,6 @@ public class TenantMgtAdminService extends AbstractAdmin {
      * @param tenantDomain tenant domain
      */
     private void audit(String tenantDomain, int tenantId) {
-
         audit_log.info("[Tenant Domain : " + tenantDomain + ", Tenant Id : " + tenantId + "] is deleted by "
                 + PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername());
     }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -590,7 +590,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                     if (TenantMgtServiceComponent.getBillingService() != null) {
                         TenantMgtServiceComponent.getBillingService().deleteBillingData(tenantId);
                     }
-                     // Before deleting the tenant deactivate the tenant from the system.
+                    // Before deleting the tenant deactivate the tenant from the system.
                     // Deactivation also used to clear the tenant configuration context for that particular tenant.
                     deactivateTenant(tenantDomain);
                     TenantMgtUtil.deleteWorkernodesTenant(tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -587,12 +587,14 @@ public class TenantMgtAdminService extends AbstractAdmin {
                 // Deactivation also used to clear the tenant configuration context for that particular tenant.
                 deactivateTenant(tenantDomain);
                 TenantMgtUtil.deleteWorkernodesTenant(tenantId);
-
+                // Checks whether tenant deletion property is set as true or not.
+                // Property can be configured in conf/carbon.xml.
+                // <TenantDelete>true</TenantDelete> with in <server> tag.
                 String tenantDelete = TenantMgtServiceComponent.getServerConfigurationService()
                         .getFirstProperty("TenantDelete");
 
-                if ((tenantDelete == null)
-                    || (tenantDelete.equals("true"))) {
+                if ((tenantDelete != null)
+                    && (tenantDelete.equals("true"))) {
                     log.info("Tenant Delete Flag is True");
                     if (TenantMgtServiceComponent.getBillingService() != null) {
                         TenantMgtServiceComponent.getBillingService().deleteBillingData(tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -587,7 +587,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                 // <TenantDelete>true</TenantDelete> with in <server> tag.
                 String tenantDelete = TenantMgtServiceComponent.getServerConfigurationService()
                         .getFirstProperty("TenantDelete");
-                if ("true".equals(tenantDelete)) {
+                if (Boolean.valueOf(tenantDelete)) {
                     log.info("Tenant Delete Flag is True");
                     if (TenantMgtServiceComponent.getBillingService() != null) {
                         TenantMgtServiceComponent.getBillingService().deleteBillingData(tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -581,24 +581,21 @@ public class TenantMgtAdminService extends AbstractAdmin {
             int tenantId = tenantManager.getTenantId(tenantDomain);
             try {
                 log.info("Starting Tenant Deletion process...");
-
-                notifyTenantDeletion(tenantId);
-                // Before deleting the tenant deactivate the tenant from the system.
-                // Deactivation also used to clear the tenant configuration context for that particular tenant.
-                deactivateTenant(tenantDomain);
-                TenantMgtUtil.deleteWorkernodesTenant(tenantId);
                 // Checks whether tenant deletion property is set as true or not.
                 // Property can be configured in conf/carbon.xml.
                 // <TenantDelete>true</TenantDelete> with in <server> tag.
                 String tenantDelete = TenantMgtServiceComponent.getServerConfigurationService()
                         .getFirstProperty("TenantDelete");
-
                 if ((tenantDelete != null)
                     && (tenantDelete.equals("true"))) {
                     log.info("Tenant Delete Flag is True");
                     if (TenantMgtServiceComponent.getBillingService() != null) {
                         TenantMgtServiceComponent.getBillingService().deleteBillingData(tenantId);
                     }
+                     // Before deleting the tenant deactivate the tenant from the system.
+                    // Deactivation also used to clear the tenant configuration context for that particular tenant.
+                    deactivateTenant(tenantDomain);
+                    TenantMgtUtil.deleteWorkernodesTenant(tenantId);
                     // Invalidate the realm in cache.
                     TenantMgtServiceComponent.getRealmService().clearCachedUserRealm(tenantId);
                     // Clear Caches and  shutdown Cache Managers.

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -574,7 +574,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
      *
      * @param tenantDomain The domain name of the tenant that needs to be deleted
      */
-    public void deleteTenant(String tenantDomain) throws StratosException, org.wso2.carbon.user.api.UserStoreException {
+    public void deleteTenant(String tenantDomain) throws TenantManagementException, org.wso2.carbon.user.api.UserStoreException {
         TenantManager tenantManager = TenantMgtServiceComponent.getTenantManager();
         if (tenantManager != null) {
             int tenantId = tenantManager.getTenantId(tenantDomain);
@@ -621,7 +621,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                 String msg = "Error deleting tenant with domain: " + tenantDomain + " and tenant id: " +
                         tenantId + ".";
                 log.error(msg, e);
-                throw new StratosException(msg, e);
+                throw new TenantManagementException(msg, e);
             }
         }
 

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.tenant.mgt.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class TenantIDNDataDeletionUtil {
+
+    public static final Log log = LogFactory.getLog(TenantIDNDataDeletionUtil.class);
+
+    /**
+     * Delete all tenant information related to tenant stored in IDN tables
+     *
+     * @param tenantId id of tenant whose data should be deleted
+     * @param conn     database connection object
+     * @throws SQLException thrown if an error occurs while executing the queries
+     */
+    protected static void deleteTenantIDNData(int tenantId, Connection conn) throws Exception {
+
+        try {
+            conn.setAutoCommit(false);
+            String deleteCM_PURPOSE_CATEGORYSql = "DELETE FROM CM_PURPOSE_CATEGORY WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteCM_PURPOSE_CATEGORYSql, tenantId);
+
+            String deleteIDN_CLAIMSql = "DELETE FROM IDN_CLAIM WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDN_CLAIMSql, tenantId);
+
+            String deleteIDN_CLAIM_DIALECTSql = "DELETE FROM IDN_CLAIM_DIALECT WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDN_CLAIM_DIALECTSql, tenantId);
+
+            String deleteIDN_CLAIM_MAPPED_ATTRIBUTESql = "DELETE FROM IDN_CLAIM_MAPPED_ATTRIBUTE WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDN_CLAIM_MAPPED_ATTRIBUTESql, tenantId);
+
+            String deleteIDN_CLAIM_MAPPINGSql = "DELETE FROM IDN_CLAIM_MAPPING WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDN_CLAIM_MAPPINGSql, tenantId);
+
+            String deleteIDN_CLAIM_PROPERTYSql = "DELETE FROM IDN_CLAIM_PROPERTY WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDN_CLAIM_PROPERTYSql, tenantId);
+
+            String deleteIDN_OIDC_SCOPESql = "DELETE FROM IDN_OIDC_SCOPE WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDN_OIDC_SCOPESql, tenantId);
+
+            String deleteIDPSql = "DELETE FROM IDP WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDPSql, tenantId);
+
+            String deleteIDP_AUTHENTICATORSql = "DELETE FROM IDP_AUTHENTICATOR WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDP_AUTHENTICATORSql, tenantId);
+
+            String deleteIDP_AUTHENTICATOR_PROPERTYSql = "DELETE FROM IDP_AUTHENTICATOR_PROPERTY WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDP_AUTHENTICATOR_PROPERTYSql, tenantId);
+
+            String deleteIDP_METADATASql = "DELETE FROM IDP_METADATA WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDP_METADATASql, tenantId);
+
+            String deleteIDP_PROVISIONING_CONFIGSql = "DELETE FROM IDP_PROVISIONING_CONFIG WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDP_PROVISIONING_CONFIGSql, tenantId);
+
+            String deleteIDP_PROV_CONFIG_PROPERTYSql = "DELETE FROM IDP_PROV_CONFIG_PROPERTY WHERE TENANT_ID = ?";
+            executeDeleteQuery(conn, deleteIDP_PROV_CONFIG_PROPERTYSql, tenantId);
+
+            conn.commit();
+        } catch (Exception e) {
+            conn.rollback();
+            String errorMsg = "An error occurred while deleting registry data for tenant: " + tenantId;
+            log.error(errorMsg, e);
+            throw new Exception(errorMsg, e);
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Initialise prepared statements for given query and execute the prepared statement.
+     * @param conn database connection object
+     * @param query query for prepared statement
+     * @param tenantId tenant id
+     * @throws Exception thrown if an error occurs while executing the query.
+     */
+    private static void executeDeleteQuery(Connection conn, String query, int tenantId)
+            throws Exception {
+
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(query);
+            ps.setInt(1, tenantId);
+            int i=ps.executeUpdate();
+            System.out.print(i+"\n");
+        } catch (SQLException e) {
+            String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
+            log.error(errMsg, e);
+            throw new Exception(errMsg, e);
+        } finally {
+            if (ps != null) {
+                ps.close();
+            }
+        }
+    }
+}

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -94,7 +94,6 @@ public class TenantIDNDataDeletionUtil {
             ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
-            log.error(errMsg, e);
             throw new SQLException(errMsg, e);
         }
     }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -91,8 +91,9 @@ public class TenantIDNDataDeletionUtil {
 
     /**
      * Initialise prepared statements for given query and execute the prepared statement.
-     * @param conn database connection object
-     * @param query query for prepared statement
+     *
+     * @param conn     database connection object
+     * @param query    query for prepared statement
      * @param tenantId tenant id
      * @throws Exception thrown if an error occurs while executing the query.
      */
@@ -103,8 +104,7 @@ public class TenantIDNDataDeletionUtil {
         try {
             ps = conn.prepareStatement(query);
             ps.setInt(1, tenantId);
-            int i=ps.executeUpdate();
-            System.out.print(i+"\n");
+            ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             log.error(errMsg, e);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -77,7 +77,6 @@ public class TenantIDNDataDeletionUtil {
             conn.close();
         }
     }
-
     /**
      * Initialise prepared statements for given query and execute the prepared statement.
      *
@@ -88,7 +87,6 @@ public class TenantIDNDataDeletionUtil {
      */
     private static void executeDeleteQuery(Connection conn, String query, int tenantId)
             throws SQLException {
-
         try (PreparedStatement ps = conn.prepareStatement(query)) {
             ps.setInt(1, tenantId);
             ps.executeUpdate();

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -25,6 +25,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+/**
+ * This Util class executes queries to delete particular tenant entries in IDN Tables. 
+ */
 public class TenantIDNDataDeletionUtil {
 
     public static final Log log = LogFactory.getLog(TenantIDNDataDeletionUtil.class);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -51,7 +51,6 @@ public class TenantIDNDataDeletionUtil {
      * @throws SQLException thrown if an error occurs while executing the queries
      */
     protected static void deleteTenantIDNData(int tenantId, Connection conn) throws SQLException {
-
         try {
             conn.setAutoCommit(false);
             executeDeleteQuery(conn, DELETE_CM_PURPOSE_CATEGORY, tenantId);
@@ -71,12 +70,12 @@ public class TenantIDNDataDeletionUtil {
         } catch (Exception e) {
             conn.rollback();
             String errorMsg = "An error occurred while deleting identity data for tenant: " + tenantId;
-            log.error(errorMsg, e);
             throw new SQLException(errorMsg, e);
         } finally {
             conn.close();
         }
     }
+    
     /**
      * Initialise prepared statements for given query and execute the prepared statement.
      *

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.tenant.mgt.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -28,6 +29,20 @@ public class TenantIDNDataDeletionUtil {
 
     public static final Log log = LogFactory.getLog(TenantIDNDataDeletionUtil.class);
 
+    private static final String DELETE_CM_PURPOSE_CATEGORY = "DELETE FROM CM_PURPOSE_CATEGORY WHERE TENANT_ID = ?";
+    private static final String DELETE_IDN_CLAIM = "DELETE FROM IDN_CLAIM WHERE TENANT_ID = ?";
+    private static final String DELETE_IDN_CLAIM_DIALECT = "DELETE FROM IDN_CLAIM_DIALECT WHERE TENANT_ID = ?";
+    private static final String DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE = "DELETE FROM IDN_CLAIM_MAPPED_ATTRIBUTE WHERE TENANT_ID = ?";
+    private static final String DELETE_IDN_CLAIM_MAPPING = "DELETE FROM IDN_CLAIM_MAPPING WHERE TENANT_ID = ?";
+    private static final String DELETE_IDN_CLAIM_PROPERTY = "DELETE FROM IDN_CLAIM_PROPERTY WHERE TENANT_ID = ?";
+    private static final String DELETE_IDN_OIDC_SCOPE = "DELETE FROM IDN_OIDC_SCOPE WHERE TENANT_ID = ?";
+    private static final String DELETE_IDP = "DELETE FROM IDP WHERE TENANT_ID = ?";
+    private static final String DELETE_IDP_AUTHENTICATOR = "DELETE FROM IDP_AUTHENTICATOR WHERE TENANT_ID = ?";
+    private static final String DELETE_IDP_AUTHENTICATOR_PROPERTY = "DELETE FROM IDP_AUTHENTICATOR_PROPERTY WHERE TENANT_ID = ?";
+    private static final String DELETE_IDP_METADATA = "DELETE FROM IDP_METADATA WHERE TENANT_ID = ?";
+    private static final String DELETE_IDP_PROVISIONING_CONFIG = "DELETE FROM IDP_PROVISIONING_CONFIG WHERE TENANT_ID = ?";
+    private static final String DELETE_IDP_PROV_CONFIG_PROPERTY = "DELETE FROM IDP_PROV_CONFIG_PROPERTY WHERE TENANT_ID = ?";
+
     /**
      * Delete all tenant information related to tenant stored in IDN tables
      *
@@ -35,55 +50,29 @@ public class TenantIDNDataDeletionUtil {
      * @param conn     database connection object
      * @throws SQLException thrown if an error occurs while executing the queries
      */
-    protected static void deleteTenantIDNData(int tenantId, Connection conn) throws Exception {
+    protected static void deleteTenantIDNData(int tenantId, Connection conn) throws SQLException {
 
         try {
             conn.setAutoCommit(false);
-            String deleteCM_PURPOSE_CATEGORYSql = "DELETE FROM CM_PURPOSE_CATEGORY WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteCM_PURPOSE_CATEGORYSql, tenantId);
-
-            String deleteIDN_CLAIMSql = "DELETE FROM IDN_CLAIM WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDN_CLAIMSql, tenantId);
-
-            String deleteIDN_CLAIM_DIALECTSql = "DELETE FROM IDN_CLAIM_DIALECT WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDN_CLAIM_DIALECTSql, tenantId);
-
-            String deleteIDN_CLAIM_MAPPED_ATTRIBUTESql = "DELETE FROM IDN_CLAIM_MAPPED_ATTRIBUTE WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDN_CLAIM_MAPPED_ATTRIBUTESql, tenantId);
-
-            String deleteIDN_CLAIM_MAPPINGSql = "DELETE FROM IDN_CLAIM_MAPPING WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDN_CLAIM_MAPPINGSql, tenantId);
-
-            String deleteIDN_CLAIM_PROPERTYSql = "DELETE FROM IDN_CLAIM_PROPERTY WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDN_CLAIM_PROPERTYSql, tenantId);
-
-            String deleteIDN_OIDC_SCOPESql = "DELETE FROM IDN_OIDC_SCOPE WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDN_OIDC_SCOPESql, tenantId);
-
-            String deleteIDPSql = "DELETE FROM IDP WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDPSql, tenantId);
-
-            String deleteIDP_AUTHENTICATORSql = "DELETE FROM IDP_AUTHENTICATOR WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDP_AUTHENTICATORSql, tenantId);
-
-            String deleteIDP_AUTHENTICATOR_PROPERTYSql = "DELETE FROM IDP_AUTHENTICATOR_PROPERTY WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDP_AUTHENTICATOR_PROPERTYSql, tenantId);
-
-            String deleteIDP_METADATASql = "DELETE FROM IDP_METADATA WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDP_METADATASql, tenantId);
-
-            String deleteIDP_PROVISIONING_CONFIGSql = "DELETE FROM IDP_PROVISIONING_CONFIG WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDP_PROVISIONING_CONFIGSql, tenantId);
-
-            String deleteIDP_PROV_CONFIG_PROPERTYSql = "DELETE FROM IDP_PROV_CONFIG_PROPERTY WHERE TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteIDP_PROV_CONFIG_PROPERTYSql, tenantId);
-
+            executeDeleteQuery(conn, DELETE_CM_PURPOSE_CATEGORY, tenantId);
+            executeDeleteQuery(conn, DELETE_IDN_CLAIM, tenantId);
+            executeDeleteQuery(conn, DELETE_IDN_CLAIM_DIALECT, tenantId);
+            executeDeleteQuery(conn, DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE, tenantId);
+            executeDeleteQuery(conn, DELETE_IDN_CLAIM_MAPPING, tenantId);
+            executeDeleteQuery(conn, DELETE_IDN_CLAIM_PROPERTY, tenantId);
+            executeDeleteQuery(conn, DELETE_IDN_OIDC_SCOPE, tenantId);
+            executeDeleteQuery(conn, DELETE_IDP, tenantId);
+            executeDeleteQuery(conn, DELETE_IDP_AUTHENTICATOR, tenantId);
+            executeDeleteQuery(conn, DELETE_IDP_AUTHENTICATOR_PROPERTY, tenantId);
+            executeDeleteQuery(conn, DELETE_IDP_METADATA, tenantId);
+            executeDeleteQuery(conn, DELETE_IDP_PROVISIONING_CONFIG, tenantId);
+            executeDeleteQuery(conn, DELETE_IDP_PROV_CONFIG_PROPERTY, tenantId);
             conn.commit();
         } catch (Exception e) {
             conn.rollback();
-            String errorMsg = "An error occurred while deleting registry data for tenant: " + tenantId;
+            String errorMsg = "An error occurred while deleting identity data for tenant: " + tenantId;
             log.error(errorMsg, e);
-            throw new Exception(errorMsg, e);
+            throw new SQLException(errorMsg, e);
         } finally {
             conn.close();
         }
@@ -95,24 +84,18 @@ public class TenantIDNDataDeletionUtil {
      * @param conn     database connection object
      * @param query    query for prepared statement
      * @param tenantId tenant id
-     * @throws Exception thrown if an error occurs while executing the query.
+     * @throws SQLException thrown if an error occurs while executing the query.
      */
     private static void executeDeleteQuery(Connection conn, String query, int tenantId)
-            throws Exception {
+            throws SQLException {
 
-        PreparedStatement ps = null;
-        try {
-            ps = conn.prepareStatement(query);
+        try (PreparedStatement ps = conn.prepareStatement(query)) {
             ps.setInt(1, tenantId);
             ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             log.error(errMsg, e);
-            throw new Exception(errMsg, e);
-        } finally {
-            if (ps != null) {
-                ps.close();
-            }
+            throw new SQLException(errMsg, e);
         }
     }
 }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantIDNDataDeletionUtil.java
@@ -50,7 +50,7 @@ public class TenantIDNDataDeletionUtil {
      * @param conn     database connection object
      * @throws SQLException thrown if an error occurs while executing the queries
      */
-    protected static void deleteTenantIDNData(int tenantId, Connection conn) throws SQLException {
+    public static void deleteTenantIDNData(int tenantId, Connection conn) throws SQLException {
         try {
             conn.setAutoCommit(false);
             executeDeleteQuery(conn, DELETE_CM_PURPOSE_CATEGORY, tenantId);
@@ -67,6 +67,9 @@ public class TenantIDNDataDeletionUtil {
             executeDeleteQuery(conn, DELETE_IDP_PROVISIONING_CONFIG, tenantId);
             executeDeleteQuery(conn, DELETE_IDP_PROV_CONFIG_PROPERTY, tenantId);
             conn.commit();
+            if (log.isDebugEnabled()) {
+                log.debug("IDN table entries deleted for tenant :" + tenantId);
+            }
         } catch (Exception e) {
             conn.rollback();
             String errorMsg = "An error occurred while deleting identity data for tenant: " + tenantId;
@@ -89,6 +92,9 @@ public class TenantIDNDataDeletionUtil {
         try (PreparedStatement ps = conn.prepareStatement(query)) {
             ps.setInt(1, tenantId);
             ps.executeUpdate();
+            if (log.isDebugEnabled()) {
+                log.debug("Deletion query : " + query + "executed for tenant :" + tenantId);
+            }
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             throw new SQLException(errMsg, e);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -461,6 +461,12 @@ public class TenantMgtUtil {
         }*/
     }
 
+    /**
+     * Delete Registry table entries.
+     *
+     * @param tenantId tenant id
+     * @throws Exception throws if any error occurred while deleting Registry table entries.
+     */
     public static void deleteTenantRegistryData(int tenantId) throws Exception {
         // delete data from mounted config registry database
         JDBCDataAccessManager configMgr = (JDBCDataAccessManager) TenantMgtServiceComponent.getRegistryService().
@@ -474,7 +480,14 @@ public class TenantMgtUtil {
 
     }
 
+    /**
+     * Delete UM table entries.
+     *
+     * @param tenantId tenant id
+     * @throws Exception throws if any error occurred while deleting UM table entries.
+     */
     public static void deleteTenantUMData(int tenantId) throws Exception {
+
         RealmConfiguration realmConfig = TenantMgtServiceComponent.getRealmService().
                 getBootstrapRealmConfiguration();
         TenantUMDataDeletionUtil.deleteTenantUMData(tenantId, DatabaseUtil.getRealmDataSource(realmConfig).
@@ -483,12 +496,13 @@ public class TenantMgtUtil {
     }
 
     /**
-     * Delete the IDN table entries.
+     * Delete IDN table entries.
      *
      * @param tenantId Tenant Id
      * @throws Exception thrown if an error occurs while executing the queries.
      */
     public static void deleteTenantIDNData(int tenantId) throws Exception {
+
         RealmConfiguration realmConfig = TenantMgtServiceComponent.getRealmService().
                 getBootstrapRealmConfiguration();
         TenantIDNDataDeletionUtil.deleteTenantIDNData(tenantId, DatabaseUtil.getRealmDataSource(realmConfig).
@@ -502,8 +516,8 @@ public class TenantMgtUtil {
      * @param tenantId tenant id
      */
     public static void deleteWorkernodesTenant(int tenantId) {
-        TenantDeleteClusterMessage clustermessage = new TenantDeleteClusterMessage(
-                tenantId);
+
+        TenantDeleteClusterMessage clustermessage = new TenantDeleteClusterMessage(tenantId);
         ConfigurationContext configContext = TenantMgtServiceComponent.getConfigurationContext();
         ClusteringAgent agent = configContext.getAxisConfiguration()
                 .getClusteringAgent();
@@ -515,7 +529,6 @@ public class TenantMgtUtil {
         } catch (ClusteringFault e) {
             log.error("Error occurred while broadcasting TenantDeleteClusterMessage : " + e.getMessage());
         }
-
     }
 
 

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -25,7 +25,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 /**
- * This Util executes queries to delete particular tenant entries in Registry Tables. 
+ * This Util class executes queries to delete particular tenant entries in Registry Tables. 
  */
 public class TenantRegistryDataDeletionUtil {
 

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.tenant.mgt.util;
 
@@ -29,6 +29,27 @@ public class TenantRegistryDataDeletionUtil {
 
     public static final Log log = LogFactory.getLog(TenantRegistryDataDeletionUtil.class);
 
+    private static final String DELETE_CLUSTER_LOCK = "DELETE FROM REG_CLUSTER_LOCK WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_LOG = "DELETE FROM REG_LOG WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_ASSOCIATION = "DELETE FROM REG_ASSOCIATION WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_SNAPSHOT = "DELETE FROM REG_SNAPSHOT WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RESOURCE_COMMENT = "DELETE FROM REG_RESOURCE_COMMENT WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_COMMENT = "DELETE FROM REG_COMMENT WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RESOURCE_RATING = "DELETE FROM REG_RESOURCE_RATING WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RATING = "DELETE FROM REG_RATING WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RESOURCE_TAG = "DELETE FROM REG_RESOURCE_TAG WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_TAG = "DELETE FROM REG_TAG WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RESOURCE_PROPERTY = "DELETE FROM REG_RESOURCE_PROPERTY WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_PROPERTY = "DELETE FROM REG_PROPERTY WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RESOURCE_HISTORY = "DELETE FROM REG_RESOURCE_HISTORY WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_CONTENT_HISTORY = "DELETE FROM REG_CONTENT_HISTORY WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_RESOURCE = "DELETE FROM REG_RESOURCE WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_CONTENT = "DELETE FROM REG_CONTENT WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_PATH = "DELETE FROM REG_PATH WHERE REG_TENANT_ID = ?";
+    private static final String DELETE_ADMIN_REGISTRY_RESORUCE = "DELETE FROM REG_RESOURCE WHERE REG_PATH_ID IN " +
+            "(SELECT DISTINCT REG_PATH_ID FROM REG_PATH WHERE REG_PATH_VALUE LIKE ?)";
+    private static final String DELETE_ADMIN_REGISTRY_PATH = "DELETE FROM REG_PATH WHERE REG_PATH_VALUE LIKE ?";
+
     /**
      * Delete all tenant information related to tenant stored in REG tables.
      *
@@ -36,122 +57,72 @@ public class TenantRegistryDataDeletionUtil {
      * @param conn     database connection object
      * @throws SQLException thrown if an error occurs while executing the queries
      */
-    protected static void deleteTenantRegistryData(int tenantId, Connection conn) throws Exception {
+    protected static void deleteTenantRegistryData(int tenantId, Connection conn) throws SQLException {
 
         try {
             conn.setAutoCommit(false);
-            String deleteClusterLockSql = "DELETE FROM REG_CLUSTER_LOCK WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteClusterLockSql, tenantId);
-
-            String deleteLogSql = "DELETE FROM REG_LOG WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteLogSql, tenantId);
-
-            String deleteAssociationSql = "DELETE FROM REG_ASSOCIATION WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteAssociationSql, tenantId);
-
-            String deleteSnapshotSql = "DELETE FROM REG_SNAPSHOT WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteSnapshotSql, tenantId);
-
-            String deleteResourceCommentSql = "DELETE FROM REG_RESOURCE_COMMENT WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteResourceCommentSql, tenantId);
-
-            String deleteCommentSql = "DELETE FROM REG_COMMENT WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteCommentSql, tenantId);
-
-            String deleteResourceRatingSql = "DELETE FROM REG_RESOURCE_RATING WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteResourceRatingSql, tenantId);
-
-            String deleteRatingSql = "DELETE FROM REG_RATING WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteRatingSql, tenantId);
-
-            String deleteResourceTagSql = "DELETE FROM REG_RESOURCE_TAG WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteResourceTagSql, tenantId);
-
-            String deleteTagSql = "DELETE FROM REG_TAG WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteTagSql, tenantId);
-
-            String deleteResourcePropertySql = "DELETE FROM REG_RESOURCE_PROPERTY WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteResourcePropertySql, tenantId);
-
-            String deletePropertySql = "DELETE FROM REG_PROPERTY WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deletePropertySql, tenantId);
-
-            String deleteResourceHistorySql = "DELETE FROM REG_RESOURCE_HISTORY WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteResourceHistorySql, tenantId);
-
-            String deleteContentHistorySql = "DELETE FROM REG_CONTENT_HISTORY WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteContentHistorySql, tenantId);
-
-            String deleteResourceSql = "DELETE FROM REG_RESOURCE WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteResourceSql, tenantId);
-
-            String deleteContentSql = "DELETE FROM REG_CONTENT WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deleteContentSql, tenantId);
-
-            String deletePathSql = "DELETE FROM REG_PATH WHERE REG_TENANT_ID = ?";
-            executeDeleteQuery(conn, deletePathSql, tenantId);
-
-            String deleteAdminResourceSql = "DELETE FROM REG_RESOURCE WHERE REG_PATH_ID IN " +
-                    "(SELECT DISTINCT REG_PATH_ID FROM REG_PATH WHERE REG_PATH_VALUE LIKE ?)";
-            executeDeleteQueryWithLikeOperator(conn, deleteAdminResourceSql, tenantId);
-
-            String deleteAdminRegistryPathSql = "DELETE FROM REG_PATH WHERE REG_PATH_VALUE LIKE ?";
-            executeDeleteQueryWithLikeOperator(conn, deleteAdminRegistryPathSql, tenantId);
-
+            executeDeleteQuery(conn, DELETE_CLUSTER_LOCK, tenantId);
+            executeDeleteQuery(conn, DELETE_LOG, tenantId);
+            executeDeleteQuery(conn, DELETE_ASSOCIATION, tenantId);
+            executeDeleteQuery(conn, DELETE_SNAPSHOT, tenantId);
+            executeDeleteQuery(conn, DELETE_RESOURCE_COMMENT, tenantId);
+            executeDeleteQuery(conn, DELETE_COMMENT, tenantId);
+            executeDeleteQuery(conn, DELETE_RESOURCE_RATING, tenantId);
+            executeDeleteQuery(conn, DELETE_RATING, tenantId);
+            executeDeleteQuery(conn, DELETE_RESOURCE_TAG, tenantId);
+            executeDeleteQuery(conn, DELETE_TAG, tenantId);
+            executeDeleteQuery(conn, DELETE_RESOURCE_PROPERTY, tenantId);
+            executeDeleteQuery(conn, DELETE_PROPERTY, tenantId);
+            executeDeleteQuery(conn, DELETE_RESOURCE_HISTORY, tenantId);
+            executeDeleteQuery(conn, DELETE_CONTENT_HISTORY, tenantId);
+            executeDeleteQuery(conn, DELETE_RESOURCE, tenantId);
+            executeDeleteQuery(conn, DELETE_CONTENT, tenantId);
+            executeDeleteQuery(conn, DELETE_PATH, tenantId);
+            executeDeleteQueryWithLikeOperator(conn, DELETE_ADMIN_REGISTRY_RESORUCE, tenantId);
+            executeDeleteQueryWithLikeOperator(conn, DELETE_ADMIN_REGISTRY_PATH, tenantId);
             conn.commit();
         } catch (SQLException e) {
             conn.rollback();
             String errorMsg = "An error occurred while deleting registry data for tenant: " + tenantId;
             log.error(errorMsg, e);
-            throw new Exception(errorMsg, e);
+            throw new SQLException(errorMsg, e);
         } finally {
             conn.close();
         }
     }
 
     private static void executeDeleteQuery(Connection conn, String query, int tenantId)
-            throws Exception {
-        PreparedStatement ps = null;
-        try {
-            ps = conn.prepareStatement(query);
+            throws SQLException {
+
+        try (PreparedStatement ps = conn.prepareStatement(query)) {
             ps.setInt(1, tenantId);
             ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             log.error(errMsg, e);
-            throw new Exception(errMsg, e);
-        } finally {
-            if (ps != null) {
-                ps.close();
-            }
+            throw new SQLException(errMsg, e);
         }
     }
 
     /**
-     *  Initialise prepared statements for given query and execute the prepared statement.
+     * Initialise prepared statements for given query and execute the prepared statement.
      *
-     * @param conn database connection object
-     * @param query query for prepared statement
+     * @param conn     database connection object
+     * @param query    query for prepared statement
      * @param tenantId tenant id
      * @throws Exception thrown if an error occurs while executing the query.
      */
     private static void executeDeleteQueryWithLikeOperator(Connection conn, String query, int tenantId)
-            throws Exception {
+            throws SQLException {
 
-        PreparedStatement ps = null;
-        try {
-            ps = conn.prepareStatement(query);
+        try (PreparedStatement ps = conn.prepareStatement(query)) {
             String param = "%/" + String.valueOf(tenantId) + "/%";
             ps.setNString(1, param);
             ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             log.error(errMsg, e);
-            throw new Exception(errMsg, e);
-        } finally {
-            if (ps != null) {
-                ps.close();
-            }
+            throw new SQLException(errMsg, e);
         }
     }
 }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -99,7 +99,6 @@ public class TenantRegistryDataDeletionUtil {
             ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
-            log.error(errMsg, e);
             throw new SQLException(errMsg, e);
         }
     }
@@ -121,7 +120,6 @@ public class TenantRegistryDataDeletionUtil {
             ps.executeUpdate();
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
-            log.error(errMsg, e);
             throw new SQLException(errMsg, e);
         }
     }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -1,12 +1,12 @@
 /*
- *  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -90,10 +90,16 @@ public class TenantRegistryDataDeletionUtil {
             conn.close();
         }
     }
-
+    /**
+     * Initialise prepared statements for given query and execute the prepared statement.
+     *
+     * @param conn     database connection object
+     * @param query    query for prepared statement
+     * @param tenantId tenant id
+     * @throws SQLException thrown if an error occurs while executing the query.
+     */
     private static void executeDeleteQuery(Connection conn, String query, int tenantId)
             throws SQLException {
-
         try (PreparedStatement ps = conn.prepareStatement(query)) {
             ps.setInt(1, tenantId);
             ps.executeUpdate();
@@ -102,18 +108,16 @@ public class TenantRegistryDataDeletionUtil {
             throw new SQLException(errMsg, e);
         }
     }
-
     /**
      * Initialise prepared statements for given query and execute the prepared statement.
      *
      * @param conn     database connection object
      * @param query    query for prepared statement
      * @param tenantId tenant id
-     * @throws Exception thrown if an error occurs while executing the query.
+     * @throws SQLException thrown if an error occurs while executing the query.
      */
     private static void executeDeleteQueryWithLikeOperator(Connection conn, String query, int tenantId)
             throws SQLException {
-
         try (PreparedStatement ps = conn.prepareStatement(query)) {
             String param = "%/" + String.valueOf(tenantId) + "/%";
             ps.setNString(1, param);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -58,7 +58,6 @@ public class TenantRegistryDataDeletionUtil {
      * @throws SQLException thrown if an error occurs while executing the queries
      */
     protected static void deleteTenantRegistryData(int tenantId, Connection conn) throws SQLException {
-
         try {
             conn.setAutoCommit(false);
             executeDeleteQuery(conn, DELETE_CLUSTER_LOCK, tenantId);
@@ -84,12 +83,12 @@ public class TenantRegistryDataDeletionUtil {
         } catch (SQLException e) {
             conn.rollback();
             String errorMsg = "An error occurred while deleting registry data for tenant: " + tenantId;
-            log.error(errorMsg, e);
             throw new SQLException(errorMsg, e);
         } finally {
             conn.close();
         }
     }
+    
     /**
      * Initialise prepared statements for given query and execute the prepared statement.
      *
@@ -108,6 +107,7 @@ public class TenantRegistryDataDeletionUtil {
             throw new SQLException(errMsg, e);
         }
     }
+    
     /**
      * Initialise prepared statements for given query and execute the prepared statement.
      *

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -26,15 +26,18 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 public class TenantRegistryDataDeletionUtil {
+
     public static final Log log = LogFactory.getLog(TenantRegistryDataDeletionUtil.class);
 
     /**
-     * Delete all tenant information related to tenant stored in REG tables
+     * Delete all tenant information related to tenant stored in REG tables.
+     *
      * @param tenantId id of tenant whose data should be deleted
-     * @param conn database connection object
-     * @throws SQLException thrown if an error occurs while executing the queries 
+     * @param conn     database connection object
+     * @throws SQLException thrown if an error occurs while executing the queries
      */
     protected static void deleteTenantRegistryData(int tenantId, Connection conn) throws Exception {
+
         try {
             conn.setAutoCommit(false);
             String deleteClusterLockSql = "DELETE FROM REG_CLUSTER_LOCK WHERE REG_TENANT_ID = ?";
@@ -90,7 +93,7 @@ public class TenantRegistryDataDeletionUtil {
 
             String deleteAdminResourceSql = "DELETE FROM REG_RESOURCE WHERE REG_PATH_ID IN " +
                     "(SELECT DISTINCT REG_PATH_ID FROM REG_PATH WHERE REG_PATH_VALUE LIKE ?)";
-            executeDeleteQueryWithLikeOperator(conn,deleteAdminResourceSql,tenantId);
+            executeDeleteQueryWithLikeOperator(conn, deleteAdminResourceSql, tenantId);
 
             String deleteAdminRegistryPathSql = "DELETE FROM REG_PATH WHERE REG_PATH_VALUE LIKE ?";
             executeDeleteQueryWithLikeOperator(conn, deleteAdminRegistryPathSql, tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -119,7 +119,7 @@ public class TenantRegistryDataDeletionUtil {
     private static void executeDeleteQueryWithLikeOperator(Connection conn, String query, int tenantId)
             throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(query)) {
-            String param = "%/" + String.valueOf(tenantId) + "/%";
+            String param = "%/cloud-services/" + String.valueOf(tenantId) + "/%";
             ps.setNString(1, param);
             ps.executeUpdate();
         } catch (SQLException e) {

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantRegistryDataDeletionUtil.java
@@ -24,7 +24,9 @@ import org.apache.commons.logging.LogFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
+/**
+ * This Util executes queries to delete particular tenant entries in Registry Tables. 
+ */
 public class TenantRegistryDataDeletionUtil {
 
     public static final Log log = LogFactory.getLog(TenantRegistryDataDeletionUtil.class);
@@ -57,7 +59,7 @@ public class TenantRegistryDataDeletionUtil {
      * @param conn     database connection object
      * @throws SQLException thrown if an error occurs while executing the queries
      */
-    protected static void deleteTenantRegistryData(int tenantId, Connection conn) throws SQLException {
+    public static void deleteTenantRegistryData(int tenantId, Connection conn) throws SQLException {
         try {
             conn.setAutoCommit(false);
             executeDeleteQuery(conn, DELETE_CLUSTER_LOCK, tenantId);
@@ -80,6 +82,9 @@ public class TenantRegistryDataDeletionUtil {
             executeDeleteQueryWithLikeOperator(conn, DELETE_ADMIN_REGISTRY_RESORUCE, tenantId);
             executeDeleteQueryWithLikeOperator(conn, DELETE_ADMIN_REGISTRY_PATH, tenantId);
             conn.commit();
+            if (log.isDebugEnabled()) {
+                log.debug("Registry table entries deleted for tenant :" + tenantId);
+            }
         } catch (SQLException e) {
             conn.rollback();
             String errorMsg = "An error occurred while deleting registry data for tenant: " + tenantId;
@@ -102,6 +107,9 @@ public class TenantRegistryDataDeletionUtil {
         try (PreparedStatement ps = conn.prepareStatement(query)) {
             ps.setInt(1, tenantId);
             ps.executeUpdate();
+            if (log.isDebugEnabled()) {
+                log.debug("Deletion query : " + query + "executed for tenant :" + tenantId);
+            }
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             throw new SQLException(errMsg, e);
@@ -122,6 +130,9 @@ public class TenantRegistryDataDeletionUtil {
             String param = "%/cloud-services/" + String.valueOf(tenantId) + "/%";
             ps.setNString(1, param);
             ps.executeUpdate();
+            if (log.isDebugEnabled()) {
+                log.debug("Deletion query : " + query + "executed for tenant :" + tenantId);
+            }
         } catch (SQLException e) {
             String errMsg = "Error executing query " + query + " for tenant: " + tenantId;
             throw new SQLException(errMsg, e);


### PR DESCRIPTION
## Purpose
Delete Tenant service of TenantMgtAdminService has some limitations on deleting tenant. Purpose of this PR is to debug existing bugs and enhance this feature
Please note that this deletion service is functional, but this improvement also has some limitations.
Please refer the doc for further clarifications.
## Goals
Fix for the Issue [Improve Tenant Deletion via Tenant deletion Admin Service.](https://github.com/wso2/carbon-multitenancy/issues/146)
## Approach
- Deactivate the tenant
- Notify tenant deletion to worker nodes[Not tested]
- Invalidate the realm in cache.
- Clear Caches and  shutdown Cache Managers.
- Clear the Registry table entries.
- Clear the User Management table entries.
- Clear the IDN table entries.
- Delete the Deployment Folder
- Audit the progress

## Documentation
[Tenant Deletion Doc](https://docs.google.com/document/d/135FtnCyehrMKi7IL92NbKDwkdu4xZjeJOCJsst_hUTw/edit?usp=sharing)
