### PR TITLE
Cleaning up tenant deletion logic to enable tenant deletion

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -565,17 +565,19 @@ public class TenantMgtAdminService extends AbstractAdmin {
             int tenantId = tenantManager.getTenantId(tenantDomain);
 
             try {
-                log.info(String.format("Starting tenant deletion for domain: %s and tenant id: %d from the system", tenantDomain, tenantId));
+                log.debug(String.format("Starting tenant deletion for domain: %s and tenant id: %d from the system", tenantDomain, tenantId));
 
                 ServerConfigurationService serverConfigurationService = TenantMgtServiceComponent.getServerConfigurationService();
 
                 if (Boolean.parseBoolean(serverConfigurationService.getFirstProperty("Tenant.TenantDelete"))) {
-                    // TODO: 2/7/19 We need to fix listeners to enable this by default
-                    // Refer - https://github.com/wso2-support/carbon-multitenancy/issues/35
+                    /*
+                     * TODO: 2/7/19 We need to fix listeners to enable this by default
+                     * Refer - https://github.com/wso2-support/carbon-multitenancy/issues/35
+                     */
                     if (Boolean.parseBoolean(serverConfigurationService.getFirstProperty("Tenant.ListenerInvocationPolicy.InvokeOnDelete"))) {
                         notifyTenantDeletion(tenantId);
                     } else {
-                        log.info("Tenant.ListenerInvocationPolicy.InvokeOnDelete flag not set to true. Listener invocation ignored.");
+                        log.debug("Tenant.ListenerInvocationPolicy.InvokeOnDelete flag not set to true carbon.xml. Listener invocation ignored.");
                     }
 
                     TenantMgtUtil.deleteWorkernodesTenant(tenantId);
@@ -589,7 +591,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                     tenantManager.deleteTenant(tenantId);
                     log.info(String.format("Deleted tenant with domain: %s and tenant id: %d from the system.", tenantDomain, tenantId));
                 } else {
-                    log.info("TenantDelete flag not set to true. Tenant will not be deleted.");
+                    log.debug("Tenant.TenantDelete flag not set to true in carbon.xml. Tenant will not be deleted.");
                 }
             } catch (Exception e) {
                 String msg = String.format("Deleted tenant with domain: %s and tenant id: %d from the system.", tenantDomain, tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -565,7 +565,9 @@ public class TenantMgtAdminService extends AbstractAdmin {
             int tenantId = tenantManager.getTenantId(tenantDomain);
 
             try {
-                log.debug(String.format("Starting tenant deletion for domain: %s and tenant id: %d from the system", tenantDomain, tenantId));
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Starting tenant deletion for domain: %s and tenant id: %d from the system", tenantDomain, tenantId));
+                }
 
                 ServerConfigurationService serverConfigurationService = TenantMgtServiceComponent.getServerConfigurationService();
 
@@ -577,7 +579,9 @@ public class TenantMgtAdminService extends AbstractAdmin {
                     if (Boolean.parseBoolean(serverConfigurationService.getFirstProperty("Tenant.ListenerInvocationPolicy.InvokeOnDelete"))) {
                         notifyTenantDeletion(tenantId);
                     } else {
-                        log.debug("Tenant.ListenerInvocationPolicy.InvokeOnDelete flag is not set to true in carbon.xml. Listener invocation ignored.");
+                        if (log.isDebugEnabled()) {
+                            log.debug("Tenant.ListenerInvocationPolicy.InvokeOnDelete flag is not set to true in carbon.xml. Listener invocation ignored.");
+                        }
                     }
 
                     TenantMgtUtil.deleteWorkernodesTenant(tenantId);
@@ -591,7 +595,9 @@ public class TenantMgtAdminService extends AbstractAdmin {
                     tenantManager.deleteTenant(tenantId);
                     log.info(String.format("Deleted tenant with domain: %s and tenant id: %d from the system.", tenantDomain, tenantId));
                 } else {
-                    log.debug("Tenant.TenantDelete flag is not set to true in carbon.xml. Tenant will not be deleted.");
+                    if (log.isDebugEnabled()) {
+                        log.debug("Tenant.TenantDelete flag is not set to true in carbon.xml. Tenant will not be deleted.");
+                    }
                 }
             } catch (Exception e) {
                 String msg = String.format("Deleted tenant with domain: %s and tenant id: %d from the system.", tenantDomain, tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtAdminService.java
@@ -577,7 +577,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                     if (Boolean.parseBoolean(serverConfigurationService.getFirstProperty("Tenant.ListenerInvocationPolicy.InvokeOnDelete"))) {
                         notifyTenantDeletion(tenantId);
                     } else {
-                        log.debug("Tenant.ListenerInvocationPolicy.InvokeOnDelete flag not set to true carbon.xml. Listener invocation ignored.");
+                        log.debug("Tenant.ListenerInvocationPolicy.InvokeOnDelete flag is not set to true in carbon.xml. Listener invocation ignored.");
                     }
 
                     TenantMgtUtil.deleteWorkernodesTenant(tenantId);
@@ -591,7 +591,7 @@ public class TenantMgtAdminService extends AbstractAdmin {
                     tenantManager.deleteTenant(tenantId);
                     log.info(String.format("Deleted tenant with domain: %s and tenant id: %d from the system.", tenantDomain, tenantId));
                 } else {
-                    log.debug("Tenant.TenantDelete flag not set to true in carbon.xml. Tenant will not be deleted.");
+                    log.debug("Tenant.TenantDelete flag is not set to true in carbon.xml. Tenant will not be deleted.");
                 }
             } catch (Exception e) {
                 String msg = String.format("Deleted tenant with domain: %s and tenant id: %d from the system.", tenantDomain, tenantId);

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.tenant.mgt.util;
 import org.apache.axis2.clustering.ClusteringAgent;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -49,12 +50,12 @@ import org.wso2.carbon.user.core.tenant.Tenant;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import javax.naming.InitialContext;
-import javax.sql.DataSource;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import javax.naming.InitialContext;
+import javax.sql.DataSource;
 
 /**
  * Utility methods for tenant management.
@@ -425,25 +426,7 @@ public class TenantMgtUtil {
                                         int tenantId) throws Exception {
         try {
             tenantManager.deactivateTenant(tenantId);
-
-            //unloading the deactivated tenant in order to avoid serving requests to the tenant.
-            Map<String, ConfigurationContext> tenantConfigContexts = TenantAxisUtils.getTenantConfigurationContexts(
-                    TenantMgtServiceComponent.getConfigurationContext());
-            ConfigurationContext tenantConfigurationContext = tenantConfigContexts.get(tenantDomain);
-
-            if (tenantConfigurationContext != null && tenantConfigurationContext.getAxisConfiguration() != null) {
-                try {
-                    PrivilegedCarbonContext.startTenantFlow();
-                    PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-                    carbonContext.setTenantDomain(tenantDomain);
-                    carbonContext.setTenantId(tenantId);
-
-                    TenantAxisUtils.terminateTenantConfigContext(tenantConfigurationContext);
-                } finally {
-                    PrivilegedCarbonContext.endTenantFlow();
-                }
-                tenantConfigContexts.remove(tenantDomain);
-            }
+            unloadTenantConfigurations(tenantDomain, tenantId);
         } catch (UserStoreException e) {
             String msg = "Error in deactivating tenant for tenant domain: " + tenantDomain + ".";
             log.error(msg, e);
@@ -460,6 +443,33 @@ public class TenantMgtUtil {
             log.error(msg, e);
             throw new Exception(msg, e);
         }*/
+    }
+
+    /**
+     * Unloading the deactivated tenant in order to avoid serving requests to the tenant.
+     *
+     * @param tenantDomain tenant domain
+     * @param tenantId tenant Id
+     * */
+    public static void unloadTenantConfigurations(String tenantDomain, int tenantId){
+
+        Map<String, ConfigurationContext> tenantConfigContexts = TenantAxisUtils.getTenantConfigurationContexts(
+                TenantMgtServiceComponent.getConfigurationContext());
+        ConfigurationContext tenantConfigurationContext = tenantConfigContexts.get(tenantDomain);
+
+        if (tenantConfigurationContext != null && tenantConfigurationContext.getAxisConfiguration() != null) {
+            try {
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+                carbonContext.setTenantDomain(tenantDomain);
+                carbonContext.setTenantId(tenantId);
+
+                TenantAxisUtils.terminateTenantConfigContext(tenantConfigurationContext);
+            } finally {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
+            tenantConfigContexts.remove(tenantDomain);
+        }
     }
 
     public static void deleteTenantRegistryData(int tenantId) throws Exception {
@@ -497,17 +507,22 @@ public class TenantMgtUtil {
      * @throws Exception
      */
     public static void deleteWorkernodesTenant(int tenantId) throws Exception {
-        TenantDeleteClusterMessage clustermessage = new TenantDeleteClusterMessage(
-                tenantId);
-        ConfigurationContext configContext = TenantMgtServiceComponent.getConfigurationContext();
-        ClusteringAgent agent = configContext.getAxisConfiguration()
-                .getClusteringAgent();
-        try {
-            agent.sendMessage(clustermessage, true);
-        } catch (ClusteringFault e) {
-            log.error("Error occurred while broadcasting TenantDeleteClusterMessage : " + e.getMessage());
-        }
 
+        TenantDeleteClusterMessage clustermessage = new TenantDeleteClusterMessage(tenantId);
+        ConfigurationContext configContext = TenantMgtServiceComponent.getConfigurationContext();
+
+        if (configContext != null) {
+            AxisConfiguration axisConfiguration = configContext.getAxisConfiguration();
+            ClusteringAgent agent = axisConfiguration.getClusteringAgent();
+
+            if (agent != null) {
+                try {
+                    agent.sendMessage(clustermessage, true);
+                } catch (ClusteringFault e) {
+                    log.error("Error occurred while broadcasting TenantDeleteClusterMessage : " + e.getMessage());
+                }
+            }
+        }
     }
 
 

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -451,7 +451,7 @@ public class TenantMgtUtil {
      * @param tenantDomain tenant domain
      * @param tenantId tenant Id
      * */
-    public static void unloadTenantConfigurations(String tenantDomain, int tenantId){
+    public static void unloadTenantConfigurations(String tenantDomain, int tenantId) {
 
         Map<String, ConfigurationContext> tenantConfigContexts = TenantAxisUtils.getTenantConfigurationContexts(
                 TenantMgtServiceComponent.getConfigurationContext());


### PR DESCRIPTION
## Purpose

Tenant deletion is by default switched off unless Tenant.TenantDelete property is setup in carbon.xml [refer - https://github.com/wso2/carbon-kernel/pull/1923 ]. This allows this logic not to impact existing behavior. Also, it is possible to enable/disable listener invocation on a tenant deletion. This is turned off by default as we have not tested the functionality. To turn listeners on, one must set Tenant.ListenerInvocationPolicy.InvokeOnDelete to true in carbon.xml. UMData cleanup is removed from tenant deletion.

## Goals

- Correct tenant deletion logic
- Clean up Axis configurations
- Provide ability to control tenant behavior through configurations

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
Document the tenant deletion behavior exposed through TenantMgtAdminService.

This should include following configurations,

`Tenant.TenantDelete` - This property must be set to true to use TenantMgtAdminService for tenant deletion
`Tenant.ListenerInvocationPolicy.InvokeOnDelete` - This property must be set to true to enable listener invocation when a tenant get deleted

Also, sample carbon.xml elements look like below,

```
<Tenant>
    ...
    ... 
    <!-- Flag to enable or disable tenant deletion. By default tenant deletion is enabled-->
    <TenantDelete>true</TenantDelete>
        
    <!-- Configurations related to listener invocation by tenant admin service-->
    <ListenerInvocationPolicy>
           <!-- Flag to enable or disable listener invocation on tenant delete. This is disabled by default-->
           <InvokeOnDelete>false</InvokeOnDelete>
    </ListenerInvocationPolicy>
    ...
    ...
</Tenant>
```

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
Refer https://github.com/wso2/carbon-kernel/pull/1923  for configurations and caching related bug fix

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A