### PR TITLE
Import bouncycastle dependency from orbit

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
@@ -54,11 +54,12 @@
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
                             org.wso2.carbon.security.*,
+                            org.bouncycastle.*;version="${org.bouncycastle.imp.pkg.version.range}",
                             org.apache.lucene.*,
                             *;resolution:=optional
                         </Import-Package>
                         <Embed-Dependency>
-                            bcprov-jdk15on|bcpkix-jdk15on|naming-factory|naming-resources|commons-collections;scope=compile|runtime;inline=false
+                            naming-factory|naming-resources|commons-collections;scope=compile|runtime;inline=false
                         </Embed-Dependency>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
@@ -98,7 +99,7 @@
             <artifactId>org.wso2.carbon.tenant.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
+            <groupId>org.wso2.orbit.org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
@@ -106,7 +107,7 @@
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
+            <groupId>org.wso2.orbit.org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -652,12 +652,12 @@
             </dependency>
 
             <dependency>
-                <groupId>org.bouncycastle</groupId>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bcprov-jdk15.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.bouncycastle</groupId>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>${bcpkix-jdk15.version}</version>
             </dependency>
@@ -1041,8 +1041,9 @@
 
         <log4j.version>1.2.13</log4j.version>
 
-        <bcprov-jdk15.version>1.60</bcprov-jdk15.version>
-        <bcpkix-jdk15.version>1.60</bcpkix-jdk15.version>
+        <bcprov-jdk15.version>1.52.0.wso2v1</bcprov-jdk15.version>
+        <bcpkix-jdk15.version>1.60.0.wso2v1</bcpkix-jdk15.version>
+        <org.bouncycastle.imp.pkg.version.range>[1.52.0,2.0.0)</org.bouncycastle.imp.pkg.version.range>
 
         <!-- Jasper Reports Version -->
         <version.jasper>2.2.2.v201205150955</version.jasper>


### PR DESCRIPTION
## Purpose
Remove the embedded bouncycastle dependencies and import the version upgraded dependencies from the orbit.

## Goals
Upgrade the Bouncycastle version to 1.60

## Approach
> Remove the embedded dependencies
> Import dependencies exported from the orbit

## Related PRs
> https://github.com/wso2/orbit/pull/348
> https://github.com/wso2/orbit/pull/340
