### PR TITLE
Implement additional claims adding separately.

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
@@ -81,7 +81,7 @@ public class TenantMgtImpl implements TenantMgtService {
 
             // For the super tenant tenant creation, tenants are always activated as they are created.
             TenantMgtUtil.activateTenantInitially(tenantInfoBean, tenantId);
-            //This was separate out to support handlers invocation.
+            // This was separate out to support handlers invocation.
             addAdditionalClaimsToUserStore(tenant);
         } catch (Exception e) {
             if (e instanceof TenantMgtException) {

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
@@ -81,6 +81,8 @@ public class TenantMgtImpl implements TenantMgtService {
 
             // For the super tenant tenant creation, tenants are always activated as they are created.
             TenantMgtUtil.activateTenantInitially(tenantInfoBean, tenantId);
+            //This was separate out to support handlers invocation.
+            addAdditionalClaimsToUserStore(tenant);
         } catch (Exception e) {
             if (e instanceof TenantMgtException) {
                 throw (TenantMgtException) e;
@@ -199,6 +201,21 @@ public class TenantMgtImpl implements TenantMgtService {
         } finally {
             // Remove thread local variable set to identify operation triggered for a tenant admin user.
             TenantMgtUtil.clearTenantAdminCreationOperation();
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    private void addAdditionalClaimsToUserStore(Tenant tenant) throws Exception {
+
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+            carbonContext.setTenantDomain(tenant.getDomain());
+            carbonContext.setTenantId(tenant.getId());
+
+            TenantMgtUtil.addAdditionalClaimsToUserStoreManager(tenant);
+        } finally {
+            // Remove thread local variable set to identify operation triggered for a tenant admin user.
             PrivilegedCarbonContext.endTenantFlow();
         }
     }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -382,6 +382,25 @@ public class TenantMgtUtil {
             claimsMap.put(UserCoreConstants.ClaimTypeURIs.GIVEN_NAME, tenant.getAdminFirstName());
             claimsMap.put(UserCoreConstants.ClaimTypeURIs.SURNAME, tenant.getAdminLastName());
             claimsMap.put(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS, tenant.getEmail());
+
+            // Can be extended to store other user information.
+            UserStoreManager userStoreManager =
+                    (UserStoreManager) TenantMgtServiceComponent.getRealmService().
+                            getTenantUserRealm(tenant.getId()).getUserStoreManager();
+            userStoreManager.setUserClaimValues(tenant.getAdminName(), claimsMap,
+                    UserCoreConstants.DEFAULT_PROFILE);
+
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            String msg = "Error in adding claims to the user.";
+            throw new TenantManagementServerException(msg, e);
+        }
+    }
+
+    public static void addAdditionalClaimsToUserStoreManager(Tenant tenant) throws Exception {
+
+        try {
+            Map<String, String> claimsMap = new HashMap<String, String>();
+
             if (tenant.getClaimsMap() != null) {
                 for (Map.Entry<String, String> entry : tenant.getClaimsMap().entrySet()) {
                     claimsMap.put(entry.getKey(), entry.getValue());
@@ -394,7 +413,6 @@ public class TenantMgtUtil {
                             getTenantUserRealm(tenant.getId()).getUserStoreManager();
             userStoreManager.setUserClaimValues(tenant.getAdminName(), claimsMap,
                     UserCoreConstants.DEFAULT_PROFILE);
-
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             String msg = "Error in adding claims to the user.";
             throw new TenantManagementServerException(msg, e);


### PR DESCRIPTION
## Purpose
> Implement additional claims adding separately.
> Identity event handlers are not triggering for tenant admin operations. 
> This is to support password reset flow while adding a tenant. 