### PR TITLE
Remove tenant owner firstname, lastname validations

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.core/src/main/java/org/wso2/carbon/tenant/mgt/core/TenantPersistor.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.core/src/main/java/org/wso2/carbon/tenant/mgt/core/TenantPersistor.java
@@ -186,7 +186,10 @@ public class TenantPersistor {
         int tenantId;
         TenantManager tenantManager = TenantMgtCoreServiceComponent.getTenantManager();
         try {
-            if (StringUtils.isBlank(tenant.getDomain())) {
+            if (StringUtils.isBlank(tenant.getAdminName())) {
+                throw new TenantManagementClientException(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getCode(), String
+                        .format(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getMessage(), "owner name"));
+            } else if (StringUtils.isBlank(tenant.getDomain())) {
                 throw new TenantManagementClientException(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getCode(), String
                         .format(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getMessage(), "tenant domain"));
             }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.core/src/main/java/org/wso2/carbon/tenant/mgt/core/TenantPersistor.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.core/src/main/java/org/wso2/carbon/tenant/mgt/core/TenantPersistor.java
@@ -186,16 +186,7 @@ public class TenantPersistor {
         int tenantId;
         TenantManager tenantManager = TenantMgtCoreServiceComponent.getTenantManager();
         try {
-            if (StringUtils.isBlank(tenant.getAdminFirstName())) {
-                throw new TenantManagementClientException(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getCode(), String
-                        .format(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getMessage(), "owner firstName"));
-            } else if (StringUtils.isBlank(tenant.getAdminLastName())) {
-                throw new TenantManagementClientException(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getCode(), String
-                        .format(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getMessage(), "owner lastName"));
-            } else if (StringUtils.isBlank(tenant.getAdminName())) {
-                throw new TenantManagementClientException(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getCode(), String
-                        .format(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getMessage(), "owner name"));
-            } else if (StringUtils.isBlank(tenant.getDomain())) {
+            if (StringUtils.isBlank(tenant.getDomain())) {
                 throw new TenantManagementClientException(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getCode(), String
                         .format(ERROR_CODE_MISSING_REQUIRED_PARAMETER.getMessage(), "tenant domain"));
             }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -423,9 +423,15 @@ public class TenantMgtUtil {
         try {
             Map<String, String> claimsMap = new HashMap<String, String>();
 
-            claimsMap.put(UserCoreConstants.ClaimTypeURIs.GIVEN_NAME, tenant.getAdminFirstName());
-            claimsMap.put(UserCoreConstants.ClaimTypeURIs.SURNAME, tenant.getAdminLastName());
-            claimsMap.put(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS, tenant.getEmail());
+            if (StringUtils.isNotEmpty(tenant.getAdminFirstName())) {
+                claimsMap.put(UserCoreConstants.ClaimTypeURIs.GIVEN_NAME, tenant.getAdminFirstName());
+            }
+            if (StringUtils.isNotEmpty(tenant.getAdminLastName())) {
+                claimsMap.put(UserCoreConstants.ClaimTypeURIs.SURNAME, tenant.getAdminLastName());
+            }
+            if (StringUtils.isNotEmpty(tenant.getEmail())) {
+                claimsMap.put(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS, tenant.getEmail());
+            }
 
             // Can be extended to store other user information.
             UserStoreManager userStoreManager =


### PR DESCRIPTION
## Purpose
Remove tenant owner firstname, lastname validations. Now a tenant can be added without specifying the tenant owner's first name and lastname
Resolves https://github.com/wso2/product-is/issues/11274