### PR TITLE
Add regex pattern for tenant domain name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ target
 *.iws
 *.ipr
 .idea
-
+.DS_Store

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.constants.StratosConstants;
+import org.wso2.carbon.stratos.common.constants.TenantConstants;
 import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.stratos.common.exception.TenantManagementClientException;
 import org.wso2.carbon.stratos.common.exception.TenantManagementServerException;
@@ -64,6 +65,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
@@ -72,6 +75,7 @@ import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMess
 import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_EMPTY_EXTENSION;
 import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_ILLEGAL_CHARACTERS_IN_DOMAIN;
 import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_INVALID_DOMAIN;
+import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_TENANT_DOES_NOT_MATCH_REGEX_PATTERN;
 
 /**
  * Utility methods for tenant management.
@@ -221,6 +225,14 @@ public class TenantMgtUtil {
             if (lastIndexOfDot <= 0) {
                 throw new TenantManagementClientException(ERROR_CODE_EMPTY_EXTENSION);
             }
+        }
+        String regex = CommonUtil.getTenantDomainRegexPattern();
+        if (StringUtils.isNotBlank(regex)) {
+            if (!isFormatCorrect(regex, domainName)) {
+                throw new TenantManagementClientException(ERROR_CODE_TENANT_DOES_NOT_MATCH_REGEX_PATTERN.getCode(),
+                        String.format(ERROR_CODE_TENANT_DOES_NOT_MATCH_REGEX_PATTERN.getMessage(), domainName, regex));
+            }
+            return;
         }
         int indexOfDot = domainName.indexOf(DOT);
         if (indexOfDot == 0) {
@@ -741,5 +753,12 @@ public class TenantMgtUtil {
             }
         }
         return maximumItemsPerPage;
+    }
+
+    private static boolean isFormatCorrect(String regularExpression, String domainName) {
+
+        Pattern p2 = Pattern.compile(regularExpression);
+        Matcher m2 = p2.matcher(domainName);
+        return m2.matches();
     }
 }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/util/TenantMgtUtil.java
@@ -226,6 +226,7 @@ public class TenantMgtUtil {
                 throw new TenantManagementClientException(ERROR_CODE_EMPTY_EXTENSION);
             }
         }
+        // Regex validation will be skipped if it is not configured.
         String regex = CommonUtil.getTenantDomainRegexPattern();
         if (StringUtils.isNotBlank(regex)) {
             if (!isFormatCorrect(regex, domainName)) {

--- a/features/tenant-mgt/org.wso2.carbon.tenant.common.server.feature/src/main/resources/conf_templates/templates/repository/conf/multitenancy/stratos.xml.j2
+++ b/features/tenant-mgt/org.wso2.carbon.tenant.common.server.feature/src/main/resources/conf_templates/templates/repository/conf/multitenancy/stratos.xml.j2
@@ -59,7 +59,9 @@
 
     <!--A few Stratos Public Cloud Specific customizations are handled by this parameter-->
     <StratosPublicCloudSetup>{{multi_tenancy.stratos.public_cloud_setup}}</StratosPublicCloudSetup>
-
+    {% if multi_tenancy.stratos.tenant_domain_regex is defined %}
+    <TenantDomainRegexPattern>{{multi_tenancy.stratos.tenant_domain_regex}}</TenantDomainRegexPattern>
+    {% endif %}
     <!--The URL of the Paypal-->
     <PaypalUrl>{{multi_tenancy.stratos.paypal.url}}</PaypalUrl>
 

--- a/pom.xml
+++ b/pom.xml
@@ -902,7 +902,7 @@
         <imp.package.version.osgi.services>[1.2.0,1.3.0)</imp.package.version.osgi.services>
 
         <!-- Carbon Commons version-->
-        <carbon.commons.version>4.7.35</carbon.commons.version>
+        <carbon.commons.version>4.7.36</carbon.commons.version>
         <carbon.commons.import.feature.version>${carbon.commons.version}</carbon.commons.import.feature.version>
         <carbon.commons.imp.pkg.version>[4.7.0, 5.0.0)</carbon.commons.imp.pkg.version>
 


### PR DESCRIPTION
## Purpose
As a part of https://github.com/wso2/product-is/issues/11485. 

Depends on https://github.com/wso2/carbon-commons/pull/426
Once carbon-commons is merged and released, need to bump carbon-commons version here.


Below configuration should be added to deployment.toml to add regex pattern to tenant domain name. If the configuration is added, it will validate the domain name based on the regex pattern. Otherwise it will fallback to the other validations (check for illegal characters in the domain name and check for dot in the domain name)

**Eg:**
```
[multi_tenancy.stratos]
tenant_domain_regex="^[a-zA-Z]+[a-zA-Z0-9-]{2,4}$"
```