### PR TITLE
Disable tenanted theme for management console

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/src/main/java/org/wso2/carbon/theme/mgt/internal/TenantThemeMgtServiceComponent.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/src/main/java/org/wso2/carbon/theme/mgt/internal/TenantThemeMgtServiceComponent.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.theme.mgt.internal;
 
+import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.theme.mgt.util.ThemeLoadingListener;
 import org.apache.commons.logging.Log;
@@ -42,6 +44,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
         immediate = true)
 public class TenantThemeMgtServiceComponent {
 
+    private static final String ENABLE_TENANT_THEME_MANAGEMENT = "Tenant.EnableTenantThemeManagement";
     private static Log log = LogFactory.getLog(TenantThemeMgtServiceComponent.class);
 
     private static ConfigurationContextService configContextService = null;
@@ -50,6 +53,14 @@ public class TenantThemeMgtServiceComponent {
     protected void activate(ComponentContext context) {
 
         try {
+            ServerConfigurationService serverConfiguration = ServerConfiguration.getInstance();
+            String enableTenantTheme = serverConfiguration.getFirstProperty(ENABLE_TENANT_THEME_MANAGEMENT);
+            boolean enableTenantThemeMgt = enableTenantTheme == null || !enableTenantTheme.equalsIgnoreCase("false");
+            if (!enableTenantThemeMgt) {
+                log.debug("******* Multitenancy Theme Config bundle is activated. But tenant theme management" +
+                        " is disabled ******* ");
+                return;
+            }
             ThemeUtil.loadResourceThemes();
             // registering the Theme Logding Listener
             BundleContext bundleContext = context.getBundleContext();

--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/src/main/java/org/wso2/carbon/theme/mgt/internal/TenantThemeMgtServiceComponent.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/src/main/java/org/wso2/carbon/theme/mgt/internal/TenantThemeMgtServiceComponent.java
@@ -55,10 +55,10 @@ public class TenantThemeMgtServiceComponent {
         try {
             ServerConfigurationService serverConfiguration = ServerConfiguration.getInstance();
             String enableTenantTheme = serverConfiguration.getFirstProperty(ENABLE_TENANT_THEME_MANAGEMENT);
-            boolean enableTenantThemeMgt = enableTenantTheme == null || !enableTenantTheme.equalsIgnoreCase("false");
+            boolean enableTenantThemeMgt = enableTenantTheme == null || Boolean.parseBoolean(enableTenantTheme);
             if (!enableTenantThemeMgt) {
-                log.debug("******* Multitenancy Theme Config bundle is activated. But tenant theme management" +
-                        " is disabled ******* ");
+                log.debug("******* Multitenancy Theme bundle is activated. But tenant theme management" +
+                        " configuration is disabled *******  ");
                 return;
             }
             ThemeUtil.loadResourceThemes();


### PR DESCRIPTION
## Purpose
> Part of https://github.com/wso2/product-is/issues/12349

Adding this config to deployment.toml will disable the tenant management console theme,
```
[tenant_mgt]
enable_tenant_theme_mgt = false
```