### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -921,15 +921,15 @@
         <carbon.registry.imp.pkg.version>[4.4.0, 5.0.0)</carbon.registry.imp.pkg.version>
 
         <!-- Carbon Identity version-->
-        <carbon.identity.version>5.20.107</carbon.identity.version>
+        <carbon.identity.version>6.0.0</carbon.identity.version>
         <carbon.identity.um.ws.api.version>5.3.3</carbon.identity.um.ws.api.version>
-        <identity.authenticator.saml2.sso.import.feature.version>5.4.4</identity.authenticator.saml2.sso.import.feature.version>
-        <carbon.identity.imp.pkg.version>[5.14.0, 6.0.0)</carbon.identity.imp.pkg.version>
+        <identity.authenticator.saml2.sso.import.feature.version>6.0.0</identity.authenticator.saml2.sso.import.feature.version>
+        <carbon.identity.imp.pkg.version>[6.0.0, 7.0.0)</carbon.identity.imp.pkg.version>
 
         <!-- Carbon Multi-tenancy version-->
-        <carbon.multitenancy.version>4.11.0</carbon.multitenancy.version>
+        <carbon.multitenancy.version>5.0.0</carbon.multitenancy.version>
         <carbon.multitenancy.exp.pkg.version>${carbon.multitenancy.version}</carbon.multitenancy.exp.pkg.version>
-        <carbon.multitenancy.imp.pkg.version>[4.7.0, 5.0.0)</carbon.multitenancy.imp.pkg.version>
+        <carbon.multitenancy.imp.pkg.version>[5.0.0, 6.0.0)</carbon.multitenancy.imp.pkg.version>
 
         <previous.version>4.2.0</previous.version>
         <version.jettison>1.3.4</version.jettison>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16