### PR TITLE
Disable always updating themes in registry on server startup

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/src/main/java/org/wso2/carbon/theme/mgt/util/ThemeUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/src/main/java/org/wso2/carbon/theme/mgt/util/ThemeUtil.java
@@ -122,7 +122,9 @@ public class ThemeUtil {
                     // This is a Directory add a new collection
                     // This path is used to store the file resource under registry
                     Collection newCollection = registry.newCollection();
-                    registry.put(fileRegistryPath, newCollection);
+                    if (!registry.resourceExists(fileRegistryPath)) {
+                        registry.put(fileRegistryPath, newCollection);
+                    }
 
                     // recur
                     transferAllThemesToRegistry(file, registry, fileRegistryPath);
@@ -139,7 +141,9 @@ public class ThemeUtil {
                     }
                     newResource.setMediaType(mediaType);
                     newResource.setContentStream(new FileInputStream(file));
-                    registry.put(fileRegistryPath, newResource);
+                    if (!registry.resourceExists(fileRegistryPath)) {
+                        registry.put(fileRegistryPath, newResource);
+                    }
                 }
             }
         } catch (Exception e) {
@@ -187,7 +191,9 @@ public class ThemeUtil {
             String themeDirName = themeDir.getName();
             String fileRegistryPath = StratosConstants.ALL_THEMES_PATH + RegistryConstants.PATH_SEPARATOR + themeDirName;
             Collection newCollection = systemRegistry.newCollection();
-            systemRegistry.put(fileRegistryPath, newCollection);
+            if (!systemRegistry.resourceExists(fileRegistryPath)) {
+                systemRegistry.put(fileRegistryPath, newCollection);
+            }
             if (reloadThemes || !systemRegistry.resourceExists(fileRegistryPath)) {
                 ThemeUtil.transferAllThemesToRegistry(themeDir, systemRegistry, fileRegistryPath);
             }


### PR DESCRIPTION
## Purpose
At the server startup, all-themes resource (path: /_system/governance/repository/components/org.wso2.carbon.all-themes) and its children are written to the registry regardless of its availability in the database already (if it is already available, it will be deleted and added again).

So this an additional overhead for the server startup and can cause race conditions if two or more nodes of a setup started parallel.

This PR disables updating the all-themes resource or any of its children if the exact resource is already present in the database.