### PR TITLE
Migrate security-mgt module from framework to its own group.

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
@@ -49,7 +49,7 @@
                         <Import-Package>
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
-                            org.wso2.carbon.security.*; version="${carbon.identity.imp.pkg.version}",
+                            org.wso2.carbon.security.*; version="${org.wso2.carbon.security.mgt.version.range}",
                             org.bouncycastle.*;version="${org.bouncycastle.imp.pkg.version.range}",
                             org.apache.lucene.*,
                             org.osgi.service.component.*;version="${imp.package.version.osgi.services}",
@@ -104,7 +104,7 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>

--- a/features/tenant-mgt/org.wso2.carbon.tenant.common.feature/pom.xml
+++ b/features/tenant-mgt/org.wso2.carbon.tenant.common.feature/pom.xml
@@ -63,10 +63,10 @@
                             <propertiesFile>../../etc/feature.properties</propertiesFile>
                             <includedFeatures>
                                 <includedFeatureDef>
-                                    org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.common.server.feature:${carbon.multitenancy.version}
+                                    org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.common.server.feature:${project.version}
                                 </includedFeatureDef>
                                 <includedFeatureDef>
-                                    org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.common.ui.feature:${carbon.multitenancy.version}
+                                    org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.common.ui.feature:${project.version}
                                 </includedFeatureDef>
                             </includedFeatures>
                             <importFeatures>

--- a/features/tenant-mgt/org.wso2.carbon.tenant.common.server.feature/pom.xml
+++ b/features/tenant-mgt/org.wso2.carbon.tenant.common.server.feature/pom.xml
@@ -109,11 +109,11 @@
 
                                 <!-- Tenant Mgmt -->
                                 <bundleDef>org.json.wso2:json</bundleDef>
-                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.mgt:${carbon.multitenancy.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.mgt:${project.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.keystore.mgt</bundleDef>
-                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.mgt.core:${carbon.multitenancy.version}
+                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.mgt.core:${project.version}
                                 </bundleDef>
-                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.theme.mgt:${carbon.multitenancy.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.theme.mgt:${project.version}</bundleDef>
                                 <!-- End Tenant Mgmt -->
 
                             </bundles>

--- a/features/tenant-mgt/org.wso2.carbon.tenant.common.ui.feature/pom.xml
+++ b/features/tenant-mgt/org.wso2.carbon.tenant.common.ui.feature/pom.xml
@@ -89,7 +89,7 @@
                             <bundles>
                                 <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.redirector.servlet.ui</bundleDef>
                                 <bundleDef>
-                                    org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.redirector.servlet.stub:${carbon.multitenancy.version}
+                                    org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.redirector.servlet.stub:${project.version}
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.sso.redirector.ui</bundleDef>
                                 <!--<bundleDef>org.wso2.carbon:org.wso2.carbon.google.analytics.ui</bundleDef>-->

--- a/features/tenant-mgt/org.wso2.carbon.tenant.throttling.agent.feature/pom.xml
+++ b/features/tenant-mgt/org.wso2.carbon.tenant.throttling.agent.feature/pom.xml
@@ -66,7 +66,7 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
-                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.throttling.agent:${carbon.multitenancy.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.multitenancy:org.wso2.carbon.tenant.throttling.agent:${project.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.throttling.agent.stub:${carbon.commons.version}</bundleDef>
                             </bundles>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.common</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.wso2.identity</groupId>
@@ -581,32 +581,32 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.mgt.core</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.deployment</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.keystore.mgt</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.theme.mgt</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.throttling.agent</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
@@ -616,7 +616,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.usage.agent</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -637,12 +637,12 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.mgt.stub</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.activation</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.equinox</groupId>
@@ -653,12 +653,12 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.redirector.servlet.stub</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.theme.mgt.stub</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.tomcat</groupId>
@@ -673,24 +673,24 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.common.server.feature</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.common.ui.feature</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.dispatcher</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.redirector.servlet</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.quartz-scheduler.wso2</groupId>
@@ -700,22 +700,22 @@
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.redirector.servlet.ui</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.sso.redirector.ui</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.mgt.ui</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.theme.mgt.ui</artifactId>
-                <version>${carbon.multitenancy.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -927,8 +927,7 @@
         <carbon.identity.imp.pkg.version>[5.14.0, 7.0.0)</carbon.identity.imp.pkg.version>
 
         <!-- Carbon Multi-tenancy version-->
-        <carbon.multitenancy.version>4.11.9-SNAPSHOT</carbon.multitenancy.version>
-        <carbon.multitenancy.exp.pkg.version>${carbon.multitenancy.version}</carbon.multitenancy.exp.pkg.version>
+        <carbon.multitenancy.exp.pkg.version>${project.version}</carbon.multitenancy.exp.pkg.version>
         <carbon.multitenancy.imp.pkg.version>[4.7.0, 5.0.0)</carbon.multitenancy.imp.pkg.version>
 
         <!-- Carbon Security Mgt version-->

--- a/pom.xml
+++ b/pom.xml
@@ -483,9 +483,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <groupId>org.wso2.carbon.security.mgt</groupId>
                 <artifactId>org.wso2.carbon.security.mgt</artifactId>
-                <version>${carbon.identity.version}</version>
+                <version>${carbon.security.mgt.version}</version>
             </dependency>
 
 
@@ -930,6 +930,10 @@
         <carbon.multitenancy.version>4.11.9-SNAPSHOT</carbon.multitenancy.version>
         <carbon.multitenancy.exp.pkg.version>${carbon.multitenancy.version}</carbon.multitenancy.exp.pkg.version>
         <carbon.multitenancy.imp.pkg.version>[4.7.0, 5.0.0)</carbon.multitenancy.imp.pkg.version>
+
+        <!-- Carbon Security Mgt version-->
+        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
+        <org.wso2.carbon.security.mgt.version.range>[1.0.0, 2.0.0)</org.wso2.carbon.security.mgt.version.range>
 
         <previous.version>4.2.0</previous.version>
         <version.jettison>1.3.4</version.jettison>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR contains the changes made to migrate the security-mgt component from framework and move it to new carbon.security.mgt group. This is a milestone of the following issue[1].

### Related Issues
- https://github.com/wso2/product-is/issues/16422

### NOTE:
- Product IS PR builder will fail because the the security-mgt component used there is still old version. 
