### PR TITLE
Skip validate tenant domain for organizations with tenant domain is same as organization id

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
@@ -404,7 +404,10 @@ public class TenantMgtImpl implements TenantMgtService {
 
         try {
             CommonUtil.validateEmail(tenant.getEmail());
-            TenantMgtUtil.validateDomain(tenant.getDomain());
+            // The tenants created for sub-organizations should not need to validate the domain name as it is a UUID.
+            if (!StringUtils.equals(tenant.getAssociatedOrganizationUUID(), tenant.getDomain())) {
+                TenantMgtUtil.validateDomain(tenant.getDomain());
+            }
             checkIsSuperTenantInvoking();
         } catch (Exception e) {
             if (e instanceof TenantMgtException) {


### PR DESCRIPTION
## Purpose
>  With the organization management feature, some organization's tenant domain is in a UUID format. For those tenants, the domain validation should be skipped upon the tenant creation.

According to the proposed logic in this PR, the associate-org-id is set for tenant's created with the B2B organization management feature. Also the tenant domain and the corresponding organization ID will be same in such cases.

### Related issues
- https://github.com/wso2/product-is/issues/16359