### PR TITLE
Add FIPS integrated BouncyCastle for keystore generation

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
@@ -50,7 +50,6 @@
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
                             org.wso2.carbon.security.*,
-                            org.bouncycastle.*;version="${org.bouncycastle.imp.pkg.version.range}",
                             org.apache.lucene.*,
                             org.osgi.service.component.*;version="${imp.package.version.osgi.services}",
                             *;resolution:=optional
@@ -104,12 +103,20 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.security.mgt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.orbit.org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bc-fips</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-fips</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
@@ -166,7 +166,7 @@ public class KeyStoreGenerator {
             // Certificate details
             Date notBefore = new Date(System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30);
             Date notAfter = new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 365 * 10));
-            BigInteger serialNumber = new BigInteger(64, new SecureRandom());
+            BigInteger serialNumber = BigInteger.valueOf(new SecureRandom().nextInt());
             String commonName = "CN=" + tenantDomain + ", OU=None, O=None L=None, C=None";
             X509Certificate certificate = null;
             if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equals(getPreferredJceProviderIdentifier())) {
@@ -176,9 +176,9 @@ public class KeyStoreGenerator {
                                                                                               new X500Name(commonName),
                                                                                               keyPair.getPublic());
                 ContentSigner signer = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM).build(keyPair.getPrivate());
+                X509CertificateHolder certificateHolder = certificateBuilder.build(signer);
                 certificate = new JcaX509CertificateConverter().setProvider(
-                        ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER).getCertificate(
-                        certificateBuilder.build(signer));
+                        ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER).getCertificate(certificateHolder);
             } else {
                 AsymmetricKeyParameter privateKeyAsymKeyParam = PrivateKeyFactory.createKey(
                         keyPair.getPrivate().getEncoded());
@@ -186,9 +186,7 @@ public class KeyStoreGenerator {
 
                 ContentSigner sigGen = new BcRSAContentSignerBuilder(sigAlgId, digAlgId).build(privateKeyAsymKeyParam);
                 X509v3CertificateBuilder v3CertBuilder = new X509v3CertificateBuilder(new X500Name(commonName),
-                                                                                      BigInteger.valueOf(
-                                                                                              new SecureRandom().nextInt()),
-                                                                                      notBefore, notAfter,
+                                                                                      serialNumber, notBefore, notAfter,
                                                                                       new X500Name(commonName),
                                                                                       subPubKeyInfo);
                 X509CertificateHolder certificateHolder = v3CertBuilder.build(sigGen);

--- a/pom.xml
+++ b/pom.xml
@@ -1005,7 +1005,7 @@
 
         <bcprov-jdk15.version>1.60.0.wso2v1</bcprov-jdk15.version>
         <bcpkix-jdk15.version>1.60.0.wso2v1</bcpkix-jdk15.version>
-        <bc-fips.version>1.0.2.3</bc-fips.version>
+        <bc-fips.version>1.0.2.4</bc-fips.version>
         <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
 
         <org.bouncycastle.imp.pkg.version.range>[1.0.0,2.0.0)</org.bouncycastle.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -619,6 +619,16 @@
                 <version>${bcpkix-jdk15.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bc-fips</artifactId>
+                <version>${bc-fips.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-fips</artifactId>
+                <version>${bcpkix-fips.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.user.ws</groupId>
                 <artifactId>org.wso2.carbon.um.ws.api</artifactId>
                 <version>${carbon.identity.um.ws.api.version}</version>
@@ -995,6 +1005,9 @@
 
         <bcprov-jdk15.version>1.60.0.wso2v1</bcprov-jdk15.version>
         <bcpkix-jdk15.version>1.60.0.wso2v1</bcpkix-jdk15.version>
+        <bc-fips.version>1.0.2.3</bc-fips.version>
+        <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
+
         <org.bouncycastle.imp.pkg.version.range>[1.0.0,2.0.0)</org.bouncycastle.imp.pkg.version.range>
 
         <!-- Jasper Reports Version -->


### PR DESCRIPTION
## Purpose
> Transition back to BouncyCastle for keystore generation
> Implement two flows for FIPS compliant and FIPS-non-compliant flow
> Bump BouncyCastle to JDK 18 (latest atm)