### PR TITLE
[4.9.x] Bump bouncycastle version to jdk18on 1.77.0 version and pax-logging version to 2.2.1-wso2v2

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.activation/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.activation/pom.xml
@@ -81,7 +81,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.deployment/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.deployment/pom.xml
@@ -79,7 +79,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.dispatcher/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.dispatcher/pom.xml
@@ -78,7 +78,7 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
@@ -100,11 +100,11 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/pom.xml
@@ -79,7 +79,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
@@ -167,7 +167,7 @@ public class KeyStoreGenerator {
             Date notBefore = new Date(System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30);
             Date notAfter = new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 365 * 10));
             BigInteger serialNumber = BigInteger.valueOf(new SecureRandom().nextInt());
-            String commonName = "CN=" + tenantDomain + ", OU=None, O=None L=None, C=None";
+            String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None, C=None";
             X509Certificate certificate = null;
             if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equals(getPreferredJceProviderIdentifier())) {
                 X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(new X500Name(commonName),

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/pom.xml
@@ -67,7 +67,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.redirector.servlet.ui/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.redirector.servlet.ui/pom.xml
@@ -65,7 +65,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.redirector.servlet/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.redirector.servlet/pom.xml
@@ -77,7 +77,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt.ui/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt.ui/pom.xml
@@ -83,7 +83,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt/pom.xml
@@ -84,7 +84,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.throttling.agent/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.throttling.agent/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/tenant-mgt/org.wso2.carbon.tenant.usage.agent/pom.xml
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.usage.agent/pom.xml
@@ -85,7 +85,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
@@ -1041,7 +1041,7 @@
         <project.scm.id>my-scm-server</project.scm.id>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -604,13 +604,13 @@
 
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bcprov-jdk15.version}</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bcprov-jdk18.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bcpkix-jdk15.version}</version>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bcpkix-jdk18.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -995,8 +995,8 @@
 
         <log4j.version>1.2.13</log4j.version>
 
-        <bcprov-jdk15.version>1.60.0.wso2v1</bcprov-jdk15.version>
-        <bcpkix-jdk15.version>1.60.0.wso2v1</bcpkix-jdk15.version>
+        <bcprov-jdk18.version>1.77.0.wso2v1</bcprov-jdk18.version>
+        <bcpkix-jdk18.version>1.77.0.wso2v2</bcpkix-jdk18.version>
         <bc-fips.version>1.0.2.4</bc-fips.version>
         <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
 

--- a/service-stubs/org.wso2.carbon.tenant.theme.mgt.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.tenant.theme.mgt.stub/pom.xml
@@ -118,7 +118,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose

This PR adds the following changes,
- [Bump bouncycastle version to jdk18on 1.77.0 version](https://github.com/wso2/carbon-multitenancy/pull/263/commits/1d72e17ee08a3a92bf443ee4b898de13d4b3b69e)
- [Update CN of the cert to adhere to BC update](https://github.com/wso2/carbon-multitenancy/pull/263/commits/c0dd3aa76c09bc2f9f96fa82c50fb4fb3a51763a)
- [Bump the pax-logging version to 2.2.1-wso2v2](https://github.com/wso2/carbon-multitenancy/pull/263/commits/d7e9ad62bc740d50dcd11290bd5293186b441ec3)