### PR TITLE
Resolve absolute path for admin console.

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/activate_tenant_ajaxprocessor.jsp
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/activate_tenant_ajaxprocessor.jsp
@@ -17,6 +17,7 @@
  -->
 <%@ page import="org.wso2.carbon.tenant.mgt.ui.clients.TenantServiceClient" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <script type="text/javascript" src="../admin/js/jquery.js"></script>
 <script type="text/javascript" src="../admin/js/jquery.form.js"></script>
@@ -50,7 +51,7 @@
             serviceClient.deactivateTenant(tenantDomain);
         }
 
-        response.sendRedirect("../tenant-mgt/view_tenants.jsp");
+        response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../tenant-mgt/view_tenants.jsp", request));
 
     } catch (Exception e) {
         e.printStackTrace();

--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/submit_tenant_ajaxprocessor.jsp
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt.ui/src/main/resources/web/tenant-mgt/submit_tenant_ajaxprocessor.jsp
@@ -19,6 +19,7 @@
 <%@ page import="org.wso2.carbon.stratos.common.util.CommonUtil" %>
 <%@ page import="org.wso2.carbon.tenant.mgt.ui.utils.TenantMgtUtil" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <script type="text/javascript" src="../admin/js/jquery.js"></script>
 <script type="text/javascript" src="../admin/js/jquery.form.js"></script>
@@ -70,13 +71,15 @@
 
      // if the request is for creating a new tenant and if th domain name is available. add the tenant
             TenantMgtUtil.addTenantConfigBean(request,config,session);
-              response.sendRedirect("../tenant-mgt/view_tenants.jsp?region=region3&item=govern_view_tenants_menu&"+paramvalue);
+              response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                "../tenant-mgt/view_tenants.jsp?region=region3&item=govern_view_tenants_menu&" + paramvalue, request));
      }else if (tenantId !=null){
      //if the tenant id is given, it is a request to update.hence update the tenant info
             TenantMgtUtil.updateTenantConfigBean(request,config,session);
             isUpdating = true;
             paramvalue = "addTenant=SuccessUpdate";
-          response.sendRedirect("../tenant-mgt/view_tenants.jsp?region=region3&item=govern_view_tenants_menu&"+paramvalue);
+          response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                "../tenant-mgt/view_tenants.jsp?region=region3&item=govern_view_tenants_menu&" + paramvalue, request));
         }
 
     } catch (Exception e) {

--- a/components/tenant-mgt/org.wso2.carbon.tenant.redirector.servlet.ui/src/main/java/org/wso2/carbon/redirector/servlet/ui/filters/AllPagesFilter.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.redirector.servlet.ui/src/main/java/org/wso2/carbon/redirector/servlet/ui/filters/AllPagesFilter.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.stratos.common.constants.StratosConstants;
 import org.wso2.carbon.redirector.servlet.ui.clients.RedirectorServletServiceClient;
+import org.wso2.carbon.ui.CarbonUIUtil;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -147,7 +148,7 @@ public class AllPagesFilter implements Filter {
                     "/carbon/".equals(path) || "/carbon/admin".equals(path) ||
                     "/carbon/admin/".equals(path)) {
                 // we have to redirect the root to the login page directly
-                path = contextPath + "/carbon/admin/login.jsp";             
+                path = CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, "/carbon/admin/login.jsp", request);
             	((HttpServletResponse) servletResponse).sendRedirect(path);
                 return;
             }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt.ui/src/main/java/org/wso2/carbon/theme/mgt/ui/processors/AddThemeResourceProcessor.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt.ui/src/main/java/org/wso2/carbon/theme/mgt/ui/processors/AddThemeResourceProcessor.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.theme.mgt.ui.clients.ThemeMgtServiceClient;
 import org.wso2.carbon.ui.CarbonUIMessage;
+import org.wso2.carbon.ui.CarbonUIUtil;
 import org.wso2.carbon.ui.transports.fileupload.AbstractFileUploadExecutor;
 import org.wso2.carbon.utils.FileItemData;
 import org.wso2.carbon.utils.ServerConstants;
@@ -80,8 +81,8 @@ public class AddThemeResourceProcessor extends AbstractFileUploadExecutor {
             log.error(msg);
 
             CarbonUIMessage.sendCarbonUIMessage(msg, CarbonUIMessage.ERROR, request);
-            response.sendRedirect(
-                    "../" + webContext + "/admin/error.jsp");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                    "../" + webContext + "/admin/error.jsp", request));
 
             return false;
         }
@@ -145,8 +146,8 @@ public class AddThemeResourceProcessor extends AbstractFileUploadExecutor {
                 log.error(msg);
 
                 CarbonUIMessage.sendCarbonUIMessage(msg, CarbonUIMessage.ERROR, request);
-                response.sendRedirect(
-                        "../" + webContext + "/admin/error.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                        "../" + webContext + "/admin/error.jsp", request));
 
                 return false;
             }
@@ -163,15 +164,16 @@ public class AddThemeResourceProcessor extends AbstractFileUploadExecutor {
             String redirectTo = request.getParameter("redirectto");
             if ("theme_mgt".equals(redirectTo)) {
                 response.setHeader("Cache-Control", "no-cache, must-revalidate");
-                response.sendRedirect("../" + webContext +
-                        "/tenant-theme/theme_mgt.jsp?logoChanged=true&redirectWith=" + redirectWith);
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../" + webContext +
+                        "/tenant-theme/theme_mgt.jsp?logoChanged=true&redirectWith=" + redirectWith, request));
             }else if ("logo_mgt".equals(redirectTo)) {
                 response.setHeader("Cache-Control", "no-cache, must-revalidate");
-                response.sendRedirect("../" + webContext +
-                        "/tenant-theme/logo_mgt.jsp?logoChanged=true&redirectWith=" + redirectWith);
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../" + webContext +
+                        "/tenant-theme/logo_mgt.jsp?logoChanged=true&redirectWith=" + redirectWith, request));
             }
             else {
-                response.sendRedirect("../" + webContext + "/tenant-theme/theme_advanced.jsp?path=" + parentPath);
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                        "../" + webContext + "/tenant-theme/theme_advanced.jsp?path=" + parentPath, request));
             }
             return true;
 
@@ -181,8 +183,8 @@ public class AddThemeResourceProcessor extends AbstractFileUploadExecutor {
             log.error(msg + " " + e.getMessage());
 
             CarbonUIMessage.sendCarbonUIMessage(msg, CarbonUIMessage.ERROR, request);
-            response.sendRedirect(
-                    "../" + webContext + "/admin/error.jsp");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                    "../" + webContext + "/admin/error.jsp", request));
 
             return false;
         }

--- a/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt.ui/src/main/resources/web/tenant-theme/theme_mgt_ajaxprocessor.jsp
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.theme.mgt.ui/src/main/resources/web/tenant-theme/theme_mgt_ajaxprocessor.jsp
@@ -18,6 +18,7 @@
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
 <%@ page import="org.wso2.carbon.registry.common.ui.UIException" %>
 <%@ page import="org.wso2.carbon.theme.mgt.ui.clients.ThemeMgtServiceClient" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="java.util.UUID" %>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
@@ -38,11 +39,13 @@
                 CarbonConstants.THEME_URL_RANDOM_SUFFIX_SESSION_KEY, UUID.randomUUID().toString());        
         client.applyTheme(themeName, redirectWithStr);
         if (redirectWithStr.equals("")) {
-            response.sendRedirect("../tenant-theme/theme_mgt.jsp?updateTheme=Success&redirectWith=" + redirectWithStr);
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+             "../tenant-theme/theme_mgt.jsp?updateTheme=Success&redirectWith=" + redirectWithStr, request));
         } else {
-            response.sendRedirect("../admin/login.jsp");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../admin/login.jsp", request));
         }
     } catch (UIException e) {
-        response.sendRedirect("../tenant-theme/theme_mgt.jsp?updateTheme=Failed&redirectWith=" + redirectWithStr);
+        response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+            "../tenant-theme/theme_mgt.jsp?updateTheme=Failed&redirectWith=" + redirectWithStr, request));
     }
 %>

--- a/pom.xml
+++ b/pom.xml
@@ -901,7 +901,7 @@
 
     <properties>
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.9.23</carbon.kernel.version>
+        <carbon.kernel.version>4.10.17</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/20416

Improve code based to absolute Urls for Admin Management Console, if the `AdminConsole.ResolveAbsoluteURLs.Enable`  config is enabled.

Config can be enabled/diasbled adding following config to the deployment.toml
```
[admin_console.resolve_absolute_urls]
enable = true
```