### PR TITLE
Remove separate Public Cert Storage for Tenant's Primary Keystore on tenant creation

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
@@ -226,6 +226,7 @@ public class KeyStoreGenerator {
      */
     private void persistKeyStore(KeyStore keyStore, X509Certificate PKCertificate)
             throws KeyStoreMgtException {
+
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             keyStore.store(outputStream, password.toCharArray());
@@ -237,26 +238,7 @@ public class KeyStoreGenerator {
             KeyStoreAdmin keystoreAdmin = new KeyStoreAdmin(tenantId, govRegistry);
             keystoreAdmin.addKeyStore(outputStream.toByteArray(), keyStoreName,
                                       password, " ", KeystoreUtils.getKeyStoreFileType(tenantDomain), password);
-
-            //Create the pub. key resource
-            Resource pubKeyResource = govRegistry.newResource();
-            pubKeyResource.setContent(PKCertificate.getEncoded());
-            pubKeyResource.addProperty(SecurityConstants.PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER,
-                                       generatePubKeyFileNameAppender());
-
-            govRegistry.put(RegistryResources.SecurityManagement.TENANT_PUBKEY_RESOURCE, pubKeyResource);
-
-            //associate the public key with the keystore
-            govRegistry.addAssociation(RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName,
-                                       RegistryResources.SecurityManagement.TENANT_PUBKEY_RESOURCE,
-                                       SecurityConstants.ASSOCIATION_TENANT_KS_PUB_KEY);
-
-        } catch (RegistryException e) {
-            String msg = "Error when writing the keystore/pub.cert to registry";
-            log.error(msg, e);
-            throw new KeyStoreMgtException(msg, e);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             String msg = "Error when processing keystore/pub. cert to be stored in registry";
             log.error(msg, e);
             throw new KeyStoreMgtException(msg, e);


### PR DESCRIPTION
## Purpose

- Part of: https://github.com/wso2/product-is/issues/21359
Remove separate Public Cert Storage for Tenant's Primary KeyStore on tenant creation since it was redundant.

- With the changes done with the PR(https://github.com/wso2/carbon-kernel/pull/4099) we have improved the kernel keystore creation logic to do the above mentioned Public cert storing task as well. So storing public cert again in the KeyStoreGenerator is not required.


## Prerequisites

- Depends on: https://github.com/wso2/carbon-kernel/pull/4099