### PR TITLE
Refactor KeyStoreGenerator class

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
@@ -108,7 +108,7 @@ public class KeyStoreGenerator {
     public void generateKeyStore() throws KeyStoreMgtException {
         try {
             password = generatePassword();
-            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(KeystoreUtils.getKeyStoreFileType(tenantDomain));
+            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(KeystoreUtils.StoreFileType.defaultFileType());
             keyStore.load(null, password.toCharArray());
             X509Certificate pubCert = generateKeyPair(keyStore);
             persistKeyStore(keyStore, pubCert);
@@ -146,7 +146,7 @@ public class KeyStoreGenerator {
      */
     public boolean isKeyStoreExists(int tenantId) throws KeyStoreMgtException{
 
-        String keyStoreName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
+        String keyStoreName = generateKSNameFromDomainName();
         boolean isKeyStoreExists = false;
         try {
             isKeyStoreExists = govRegistry.resourceExists(RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName);
@@ -237,7 +237,7 @@ public class KeyStoreGenerator {
             // Use the keystore using the keystore admin
             KeyStoreAdmin keystoreAdmin = new KeyStoreAdmin(tenantId, govRegistry);
             keystoreAdmin.addKeyStore(outputStream.toByteArray(), keyStoreName,
-                                      password, " ", KeystoreUtils.getKeyStoreFileType(tenantDomain), password);
+                                      password, " ", KeystoreUtils.StoreFileType.defaultFileType(), password);
         } catch (Exception e) {
             String msg = "Error when processing keystore/pub. cert to be stored in registry";
             log.error(msg, e);


### PR DESCRIPTION
## Purpose
This pull request includes updates to the `KeyStoreGenerator` class to standardize the handling of key store file types and improve the method of generating key store names.

Key changes:

* [`KeyStoreGenerator.java`](diffhunk://#diff-287dae365d609d7368d646bdf1e60fa2ffddb41cffe175b19b359bfe5cab0093L111-R111): Modified the `generateKeyStore` method to use the default file type for key stores.
* [`KeyStoreGenerator.java`](diffhunk://#diff-287dae365d609d7368d646bdf1e60fa2ffddb41cffe175b19b359bfe5cab0093L149-R149): Updated the `isKeyStoreExists` method to generate the key store name from the domain name instead of using the file location.
* [`KeyStoreGenerator.java`](diffhunk://#diff-287dae365d609d7368d646bdf1e60fa2ffddb41cffe175b19b359bfe5cab0093L240-R240): Changed the `persistKeyStore` method to use the default file type for key stores.

## Related Issue
https://github.com/wso2/product-is/issues/21954
