### PR TITLE
bump kernel version and identity user ws to latest version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -922,7 +922,7 @@
 
         <!-- Carbon Identity version-->
         <carbon.identity.version>7.7.269</carbon.identity.version>
-        <carbon.identity.um.ws.api.version>5.8.7</carbon.identity.um.ws.api.version>
+        <carbon.identity.um.ws.api.version>5.8.9</carbon.identity.um.ws.api.version>
         <identity.authenticator.saml2.sso.import.feature.version>5.4.4</identity.authenticator.saml2.sso.import.feature.version>
         <carbon.identity.imp.pkg.version>[5.14.0, 8.0.0)</carbon.identity.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -901,7 +901,7 @@
 
     <properties>
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.10.22</carbon.kernel.version>
+        <carbon.kernel.version>4.10.47</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.10.22, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
## Purpose
- To fix the fossa scanner detecting vulnerabilities in the older carbon kernel versions.