### PR TITLE
Add pr builder

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -38,6 +38,3 @@ jobs:
             ${{ runner.os }}-
       - name: Build with Maven
         run: mvn clean install -U -B
-
-      - name: Generate coverage report
-        run: mvn test jacoco:report

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,0 +1,43 @@
+# This workflow will build the project on pull requests with tests
+# Uses:
+#   OS: ubuntu-latest
+#   JDK: Adopt JDK 11
+
+name: PR Builder
+
+on:
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+env:
+  MAVEN_OPTS: -Xmx4g -Xms1g
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Adopt JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Cache local Maven repository
+        id: cache-maven-m2
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-m2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ env.cache-name }}-
+            ${{ runner.os }}-maven-
+            ${{ runner.os }}-
+      - name: Build with Maven
+        run: mvn clean install -U -B
+
+      - name: Generate coverage report
+        run: mvn test jacoco:report


### PR DESCRIPTION
## Purpose
- This pull request introduces a new GitHub Actions workflow to automate the build and testing process for pull requests. The workflow is designed to ensure consistency and efficiency in the CI/CD pipeline by leveraging Maven and Adopt JDK 11.

### CI/CD Workflow Addition:
* [`.github/workflows/pr-builder.yml`](diffhunk://#diff-5274abb9a1f90be1adf589d21c49758b213e3aac969ac7335bfe26b7963a348eR1-R40): Added a new workflow named "PR Builder" that triggers on pull requests to the `main` or `master` branches. The workflow sets up an Ubuntu environment, configures Adopt JDK 11, caches the local Maven repository to speed up builds, and runs the Maven build process (`mvn clean install`).
