### PR TITLE
Add tenant name to the new building tenant info bean method

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
@@ -776,9 +776,13 @@ public class TenantMgtImpl implements TenantMgtService {
 
     private static TenantInfoBean buildTenantInfoBean(Tenant tenant) {
 
+        String domain = tenant.getDomain();
+        String name = tenant.getName();
+
         TenantInfoBean bean = new TenantInfoBean();
         bean.setTenantId(tenant.getId());
-        bean.setTenantDomain(tenant.getDomain());
+        bean.setTenantDomain(domain);
+        bean.setName(StringUtils.isNotBlank(name) ? name : domain);
         bean.setEmail(tenant.getEmail());
         bean.setAdmin(tenant.getAdminName());
         bean.setFirstname(tenant.getAdminFirstName());


### PR DESCRIPTION
## Purpose
$subject

As a new method is introduced in https://github.com/wso2/carbon-multitenancy/pull/293 to build the tenant info bean, the integration tests are failing due to tenant name being not set correctly.