### PR TITLE
[4.9.x] Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -899,7 +899,7 @@
 
     <properties>
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.9.29-alpha</carbon.kernel.version>
+        <carbon.kernel.version>4.9.29</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
@@ -914,7 +914,7 @@
         <carbon.analytics-common.version>5.2.18</carbon.analytics-common.version>
 
         <!-- Carbon Registry version-->
-        <carbon.registry.version>4.8.26</carbon.registry.version>
+        <carbon.registry.version>4.8.47</carbon.registry.version>
         <carbon.registry.import.feature.version>${carbon.registry.version}</carbon.registry.import.feature.version>
         <carbon.registry.imp.pkg.version>[4.4.0, 5.0.0)</carbon.registry.imp.pkg.version>
 
@@ -961,7 +961,7 @@
         <axis2.wso2.version.aar.plugin>1.6.2</axis2.wso2.version.aar.plugin>
         <neethi.osgi.version>2.0.4.wso2v5</neethi.osgi.version>
         <neethi.osgi.version.range>[2.0.4.wso2v4, 3.1.0)</neethi.osgi.version.range>
-        <axis2-transports.version>2.0.0-wso2v42</axis2-transports.version>
+        <axis2-transports.version>2.0.0-wso2v73</axis2-transports.version>
 
         <!-- Xerces Version -->
         <xercesImpl.version>2.11.0</xercesImpl.version>


### PR DESCRIPTION
## Purpose

This PR adds the following dependency version updates:

* Updated `carbon.kernel.version` from `4.9.29-alpha` to `4.9.29` to use the stable release instead of the alpha version.
* Updated `carbon.registry.version` from `4.8.26` to `4.8.47` for enhanced stability and features.
* Updated `axis2-transports.version` from `2.0.0-wso2v42` to `2.0.0-wso2v73` to incorporate the latest improvements and fixes.