### PR TITLE
Update orbit.json and pax-logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1041,7 +1041,7 @@
         <project.scm.id>my-scm-server</project.scm.id>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
-        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
+        <pax.logging.api.version>2.3.0-wso2v1</pax.logging.api.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1034,7 +1034,7 @@
         <opensaml2.wso2.version>3.3.1.wso2v1</opensaml2.wso2.version>
 
         <com.google.code.gson.version>2.10.1</com.google.code.gson.version>
-        <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
+        <orbit.version.json>3.0.0.wso2v7</orbit.version.json>
         <org.eclipse.osgi.version>3.9.1.v20130814-1242</org.eclipse.osgi.version>
         <version.equinox.osgi.services>3.3.100.v20130513-1956</version.equinox.osgi.services>
 


### PR DESCRIPTION
This PR updates several dependencies to their latest WSO2 versions to improve stability, performance, and compatibility.

### Changes Made

**Orbit Libraries:**
- **orbit.json**: `3.0.0.wso2v1` → `3.0.0.wso2v7`

**Logging Libraries:**
- **pax-logging**: `2.2.1-wso2v2` → `2.3.0-wso2v1`

Related Issue: https://github.com/wso2/api-manager/issues/3870
