### PR TITLE
[4.9.x] Upgrade axis2 and axiom versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -949,15 +949,15 @@
         <orbit.version.tomcat.servlet.api>${version.tomcat}.wso2v1</orbit.version.tomcat.servlet.api>
 
         <!-- Axiom Version -->
-        <axiom.version>1.2.11-wso2v29</axiom.version>
+        <axiom.version>1.2.11-wso2v30</axiom.version>
         <axiom.wso2.version>${axiom.version}</axiom.wso2.version>
         <orbit.version.axiom>${axiom.version}</orbit.version.axiom>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v108</axis2.wso2.version>
         <orbit.version.axis2>${axis2.wso2.version}</orbit.version.axis2>
-        <axis2.osgi.version.range>[1.6.1-wso2v105, 1.7.0)</axis2.osgi.version.range>
+        <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
         <axis2.wso2.version.aar.plugin>1.6.2</axis2.wso2.version.aar.plugin>
         <neethi.osgi.version>2.0.4.wso2v5</neethi.osgi.version>
         <neethi.osgi.version.range>[2.0.4.wso2v4, 3.1.0)</neethi.osgi.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -899,7 +899,7 @@
 
     <properties>
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.9.29</carbon.kernel.version>
+        <carbon.kernel.version>4.9.30</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
@@ -914,7 +914,7 @@
         <carbon.analytics-common.version>5.2.18</carbon.analytics-common.version>
 
         <!-- Carbon Registry version-->
-        <carbon.registry.version>4.8.47</carbon.registry.version>
+        <carbon.registry.version>4.8.50</carbon.registry.version>
         <carbon.registry.import.feature.version>${carbon.registry.version}</carbon.registry.import.feature.version>
         <carbon.registry.imp.pkg.version>[4.4.0, 5.0.0)</carbon.registry.imp.pkg.version>
 


### PR DESCRIPTION
## Purpose

This pull request updates several dependency versions in the `pom.xml` file to bring the project up to date with the latest compatible releases. These changes help ensure better stability, security, and compatibility with upstream libraries.

**Dependency version upgrades:**

* Upgraded `carbon.kernel.version` from `4.9.29` to `4.9.30` to use the latest Carbon Kernel release.
* Updated `carbon.registry.version` from `4.8.47` to `4.8.50` for improved registry support.
* Bumped `axiom.version` from `1.2.11-wso2v29` to `1.2.11-wso2v30` for the latest Axiom library.
* Increased `axis2.wso2.version` from `1.6.1-wso2v105` to `1.6.1-wso2v108`, and updated the `axis2.osgi.version.range` to `[1.6.1, 1.7.0)` for broader compatibility.