### PR TITLE
Update getTenantByDomain method to use getTenantByDomain method from org.wso2.carbon.user.api.TenantManager.

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java
@@ -179,13 +179,12 @@ public class TenantMgtImpl implements TenantMgtService {
         TenantManager tenantManager = TenantMgtServiceComponent.getTenantManager();
         Tenant tenant;
         try {
-            int tenantID = tenantManager.getTenantId(domain);
-            tenant = (Tenant) tenantManager.getTenant(tenantID);
+            tenant = (Tenant) tenantManager.getTenantByDomain(domain);
             if (tenant == null) {
                 throw new TenantManagementClientException(ERROR_CODE_DOMAIN_NOT_FOUND.getCode(),
                         String.format(ERROR_CODE_DOMAIN_NOT_FOUND.getMessage(), domain));
             }
-            String tenantName = tenantManager.getTenantNameByID(tenantID);
+            String tenantName = tenantManager.getTenantNameByID(tenant.getId());
             tenant.setName(StringUtils.isNotBlank(tenantName) ? tenantName : domain);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new TenantManagementServerException("Error while getting the tenant - " + domain, e);

--- a/pom.xml
+++ b/pom.xml
@@ -901,7 +901,7 @@
 
     <properties>
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.10.48</carbon.kernel.version>
+        <carbon.kernel.version>4.10.98</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.10.22, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Purpose
This PR updates the `getTenantByDomain` method implementation to directly use the `getTenantByDomain(String domain)` method from `org.wso2.carbon.user.api.TenantManager`, instead of fetching the tenant via `getTenantId(domain)` followed by `getTenant(tenantId)`.

## Megre After
- https://github.com/wso2/carbon-kernel/pull/4404

### Related Issue
- https://github.com/wso2/product-is/issues/24735