### PR TITLE
Add tenant EC key pair support

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
@@ -18,34 +18,34 @@
 package org.wso2.carbon.keystore.mgt;
 
 import org.apache.axiom.om.util.UUIDGenerator;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.wso2.carbon.base.ServerConfiguration;
-import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.keystore.mgt.util.RealmServiceHolder;
 import org.wso2.carbon.security.keystore.KeyStoreAdmin;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
-import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.util.Date;
+
+import static org.wso2.carbon.core.util.KeyStoreUtil.getTenantKeyAlias;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.EC_KEY_ALG;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.EC_SHA256;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_KEY_ALG;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_MD5;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_SHA1;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_SHA256;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_SHA384;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_SHA512;
+
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairUtil.addKeyEntry;
 
 /**
- * This class is used to generate a key store for a tenant and store it in the governance registry.
+ * This class is used to generate a key store for a tenant.
  * This class also provides APIs for idp-mgt component to generate a trust store with a given name.
  */
 public class KeyStoreGenerator {
@@ -56,24 +56,15 @@ public class KeyStoreGenerator {
     private String password;
     private static final String SIGNING_ALG = "Tenant.SigningAlgorithm";
 
-    // Supported signature algorithms for public certificate generation.
-    private static final String RSA_MD5 = "MD5withRSA";
-    private static final String RSA_SHA1 = "SHA1withRSA";
-    private static final String RSA_SHA256 = "SHA256withRSA";
-    private static final String RSA_SHA384 = "SHA384withRSA";
-    private static final String RSA_SHA512 = "SHA512withRSA";
     private static final String[] signatureAlgorithms = new String[]{
             RSA_MD5, RSA_SHA1, RSA_SHA256, RSA_SHA384, RSA_SHA512
     };
-
-
 
     public KeyStoreGenerator(int  tenantId) throws KeyStoreMgtException {
 
         this.tenantId = tenantId;
         this.tenantDomain = getTenantDomainName();
     }
-
 
     /**
      * This method first generates the keystore, then persist it in the gov.registry of that tenant
@@ -85,8 +76,13 @@ public class KeyStoreGenerator {
             password = generatePassword();
             KeyStore keyStore = KeystoreUtils.getKeystoreInstance(KeystoreUtils.StoreFileType.defaultFileType());
             keyStore.load(null, password.toCharArray());
-            X509Certificate pubCert = generateKeyPair(keyStore);
-            persistKeyStore(keyStore, pubCert);
+            // RSA based key pair entry
+            X509Certificate pubCertRSA =  addKeyEntry(tenantDomain, password, keyStore, tenantDomain,
+                    RSA_KEY_ALG, getSignatureAlgorithm());
+            // EC based key pair entry
+            addKeyEntry(tenantDomain, password, keyStore, getTenantKeyAlias(tenantDomain, EC_KEY_ALG),
+                    EC_KEY_ALG, EC_SHA256);
+            persistKeyStore(keyStore, pubCertRSA);
         } catch (Exception e) {
             String msg = "Error while instantiating a keystore";
             log.error(msg, e);
@@ -134,62 +130,6 @@ public class KeyStoreGenerator {
             }
         }
         return false;
-    }
-
-    /**
-     * This method generates the keypair and stores it in the keystore
-     *
-     * @param keyStore A keystore instance
-     * @return Generated public key for the tenant
-     * @throws KeyStoreMgtException Error when generating key pair
-     */
-    private X509Certificate generateKeyPair(KeyStore keyStore) throws KeyStoreMgtException {
-        try {
-            CryptoUtil.getDefaultCryptoUtil();
-            //generate key pair
-            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-            keyPairGenerator.initialize(2048);
-            KeyPair keyPair = keyPairGenerator.generateKeyPair();
-
-            // Common Name and alias for the generated certificate
-            String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None, C=None";
-
-            //generate certificates
-            X500Name distinguishedName = new X500Name(commonName);
-
-            Date notBefore = new Date(System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30);
-            Date notAfter = new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 365 * 10));
-
-            SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
-            BigInteger serialNumber = new BigInteger(32, new SecureRandom());
-
-            X509v3CertificateBuilder certificateBuilder = new X509v3CertificateBuilder(
-                    distinguishedName,
-                    serialNumber,
-                    notBefore,
-                    notAfter,
-                    distinguishedName,
-                    subPubKeyInfo
-            );
-
-            String algorithmName = getSignatureAlgorithm();
-            JcaContentSignerBuilder signerBuilder =
-                    new JcaContentSignerBuilder(algorithmName).setProvider(getJCEProvider());
-            PrivateKey privateKey = keyPair.getPrivate();
-            X509Certificate x509Cert = new JcaX509CertificateConverter().setProvider(getJCEProvider())
-                    .getCertificate(certificateBuilder.build(signerBuilder.build(privateKey)));
-
-            //add private key to KS
-            keyStore.setKeyEntry(tenantDomain, keyPair.getPrivate(), password.toCharArray(),
-                    new java.security.cert.Certificate[]{x509Cert});
-            return x509Cert;
-        } catch (Exception ex) {
-            String msg = "Error while generating the certificate for tenant :" +
-                         tenantDomain + ".";
-            log.error(msg, ex);
-            throw new KeyStoreMgtException(msg, ex);
-        }
-
     }
 
     /**
@@ -289,16 +229,7 @@ public class KeyStoreGenerator {
         }
     }
 
-    private static String getJCEProvider() {
-
-        String provider = ServerConfiguration.getInstance().getFirstProperty(ServerConstants.JCE_PROVIDER);
-        if (!StringUtils.isBlank(provider)) {
-            return provider;
-        }
-        return ServerConstants.JCE_PROVIDER_BC;
-    }
-
-    private static String getSignatureAlgorithm() {
+    private String getSignatureAlgorithm() {
 
         String algorithm = ServerConfiguration.getInstance().getFirstProperty(SIGNING_ALG);
         // Find in a list of supported signature algorithms.

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairConstants.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairConstants.java
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+*
+*  WSO2 LLC. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.wso2.carbon.keystore.mgt.util;
+
+/*
+* Constants required for Tenant KeyPair Utility.
+*/
+public class TenantKeyPairConstants {
+
+    // Constants required for EC key pair generation for existing tenants for backward compatibility
+    public static final String EC_KEY_ALG = "EC";
+    public static final String EC_CURVE = "secp256r1";
+    public static final String EC_SHA256 = "SHA256withECDSA";
+
+    // Supported signature algorithms for public certificate generation.
+    public static final String RSA_MD5 = "MD5withRSA";
+    public static final String RSA_SHA1 = "SHA1withRSA";
+    public static final String RSA_SHA256 = "SHA256withRSA";
+    public static final String RSA_SHA384 = "SHA384withRSA";
+    public static final String RSA_SHA512 = "SHA512withRSA";
+
+    public static final String RSA_KEY_ALG = "RSA";
+}

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairUtil.java
@@ -72,7 +72,7 @@ public class TenantKeyPairUtil {
             throws KeyStoreMgtException {
 
         if(LOG.isDebugEnabled()){
-            LOG.info("Adding key entry for tenant: " + tenantDomain + " with alias: " + alias
+            LOG.debug("Adding key entry for tenant: " + tenantDomain + " with alias: " + alias
                     + " and key type: " + keyType);
         }
 

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairUtil.java
@@ -71,6 +71,11 @@ public class TenantKeyPairUtil {
                                               String alias, String keyType, String sigAlgId)
             throws KeyStoreMgtException {
 
+        if(LOG.isDebugEnabled()){
+            LOG.info("Adding key entry for tenant: " + tenantDomain + " with alias: " + alias
+                    + " and key type: " + keyType);
+        }
+
         try {
             CryptoUtil.getDefaultCryptoUtil();
             KeyPairGenerator kpg;
@@ -86,7 +91,6 @@ public class TenantKeyPairUtil {
             }
             KeyPair keyPair = Objects.requireNonNull(kpg).generateKeyPair();
             X509Certificate cert = generateCertificate(tenantDomain, keyPair, sigAlgId);
-            // Add private key to Keystore
             keyStore.setKeyEntry(alias, keyPair.getPrivate(), ksPassword.toCharArray(),
                     new Certificate[]{cert});
             return cert;

--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairUtil.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/util/TenantKeyPairUtil.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.keystore.mgt.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.wso2.carbon.core.util.CryptoUtil;
+import org.wso2.carbon.keystore.mgt.KeyStoreMgtException;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Date;
+import java.util.Objects;
+
+import static org.wso2.carbon.core.util.CryptoUtil.getJCEProvider;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.EC_CURVE;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.EC_KEY_ALG;
+import static org.wso2.carbon.keystore.mgt.util.TenantKeyPairConstants.RSA_KEY_ALG;
+
+/**
+ * Utility for provisioning and validating tenant specific key pairs required.
+ */
+public class TenantKeyPairUtil {
+
+    private static final Log LOG = LogFactory.getLog(TenantKeyPairUtil.class);
+
+    private TenantKeyPairUtil() {
+    }
+
+    /**
+     * Generate and store key pair with self-signed certificate in tenant keystore.
+     *
+     * @param tenantDomain tenant domain
+     * @param ksPassword   keystore password
+     * @param keyStore     tenant keystore
+     * @param alias        key alias
+     * @param keyType      key type
+     * @param sigAlgId     signature algorithm ID
+     * @return generated certificate
+     * @throws KeyStoreMgtException keystore exception
+     */
+    public static X509Certificate addKeyEntry(String tenantDomain, String ksPassword, KeyStore keyStore,
+                                              String alias, String keyType, String sigAlgId)
+            throws KeyStoreMgtException {
+
+        try {
+            CryptoUtil.getDefaultCryptoUtil();
+            KeyPairGenerator kpg;
+
+            if (EC_KEY_ALG.equals(keyType)) {
+                kpg = KeyPairGenerator.getInstance(EC_KEY_ALG);
+                kpg.initialize(new ECGenParameterSpec(EC_CURVE));
+            } else if (RSA_KEY_ALG.equals(keyType)) {
+                kpg = KeyPairGenerator.getInstance(RSA_KEY_ALG);
+                kpg.initialize(2048);
+            } else {
+                throw new IllegalArgumentException("Unsupported key type: " + keyType);
+            }
+            KeyPair keyPair = Objects.requireNonNull(kpg).generateKeyPair();
+            X509Certificate cert = generateCertificate(tenantDomain, keyPair, sigAlgId);
+            // Add private key to Keystore
+            keyStore.setKeyEntry(alias, keyPair.getPrivate(), ksPassword.toCharArray(),
+                    new Certificate[]{cert});
+            return cert;
+        } catch (Exception e) {
+            String errorMsg = "Error while generating the certificate for tenant :" +
+                    tenantDomain + ".";
+            LOG.error(errorMsg, e);
+            throw new KeyStoreMgtException(errorMsg, e);
+        }
+    }
+
+    private static X509Certificate generateCertificate(String tenantDomain, KeyPair keyPair, String algorithmId)
+            throws CertificateException, OperatorCreationException {
+
+        String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None, C=None";
+        //generate certificate
+        X500Name distinguishedName = new X500Name(commonName);
+
+        Date notBefore = new Date(System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30);
+        Date notAfter = new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 365 * 10));
+
+        SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
+        BigInteger serialNumber = new BigInteger(32, new SecureRandom());
+
+        X509v3CertificateBuilder certificateBuilder = new X509v3CertificateBuilder(distinguishedName, serialNumber,
+                notBefore, notAfter, distinguishedName, subPubKeyInfo);
+        JcaContentSignerBuilder signerBuilder =
+                new JcaContentSignerBuilder(algorithmId).setProvider(getJCEProvider());
+
+        return new JcaX509CertificateConverter().setProvider(getJCEProvider())
+                .getCertificate(certificateBuilder.build(signerBuilder.build(keyPair.getPrivate())));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -911,7 +911,7 @@
 
     <properties>
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.10.108</carbon.kernel.version>
+        <carbon.kernel.version>4.12.15</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version>[4.10.22, 5.0.0)</carbon.kernel.imp.pkg.version>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
## PR Description
Introduces support for generating EC based key pairs for tenant keystores and refactors the tenant keystore provisioning logic.

### Key improvements include:
- Added EC key pair generation alongside the existing RSA key pair during tenant keystore creation
- Introduced `TenantKeyPairUtil` to centralize key pair generation and certificate creation logic
- Added `TenantKeyPairConstants` to define supported algorithms and signature constants
- Updated `KeyStoreGenerator` to use the new utility and generate both RSA and EC key entries
- Used `KeyStoreUtil.getTenantKeyAlias()` to resolve the EC key alias for tenants

With this change, tenant keystores will contain both RSA and EC key entries, enabling improved support for modern cryptographic algorithms while keeping the keystore generation logic modular and reusable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant keystore now creates and stores both RSA and EC key entries.
  * Added a utility to generate tenant key pairs and self-signed certificates.
  * Introduced standardized algorithm constants for RSA and EC operations.

* **Refactor**
  * Keystore generation updated to use entry-based population and simplified signature handling.

* **Chores**
  * Updated Carbon kernel dependency to version 4.12.15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->