### PR TITLE
Remove non-conforming country attribute from tenant certificate DN

### DIFF
--- a/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
+++ b/components/tenant-mgt/org.wso2.carbon.tenant.keystore.mgt/src/main/java/org/wso2/carbon/keystore/mgt/KeyStoreGenerator.java
@@ -167,7 +167,7 @@ public class KeyStoreGenerator {
             Date notBefore = new Date(System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30);
             Date notAfter = new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 365 * 10));
             BigInteger serialNumber = BigInteger.valueOf(new SecureRandom().nextInt());
-            String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None, C=None";
+            String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None";
             X509Certificate certificate = null;
             if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equals(getPreferredJceProviderIdentifier())) {
                 X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(new X500Name(commonName),


### PR DESCRIPTION

<!-- Generated: 2026-08-06 | Base: 4.13.x -->

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Tenant creation fails on any deployment using Bouncy Castle 1.85 or later.

`KeyStoreGenerator` builds the tenant certificate subject DN with a placeholder country attribute, `C=None`. Bouncy Castle 1.85 began validating `countryName` when an `X500Name` is constructed from a string, and requires the value to be exactly two characters. `None` is four, so certificate generation throws before the tenant keystore can be created:

```
java.lang.IllegalArgumentException: country code attribute 2.5.4.6 must be exactly 2 characters
  per ISO 3166-1 / X.520, got 4: 'None'
    at org.bouncycastle.asn1.x500.style.BCStyle.encodeStringValue(Unknown Source)
    at org.bouncycastle.asn1.x500.X500NameBuilder.addRDN(Unknown Source)
    at org.bouncycastle.asn1.x500.style.BCStyle.fromString(Unknown Source)
    at org.bouncycastle.asn1.x500.X500Name.<init>(Unknown Source)
    at org.wso2.carbon.keystore.mgt.KeyStoreGenerator.generateKeyPair(KeyStoreGenerator.java:188)
    at org.wso2.carbon.keystore.mgt.KeyStoreGenerator.generateKeyStore(KeyStoreGenerator.java:103)
    at org.wso2.carbon.keystore.mgt.KeystoreTenantMgtListener.onTenantCreate(KeystoreTenantMgtListener.java:43)
    at org.wso2.carbon.tenant.mgt.util.TenantMgtUtil.triggerAddTenant(TenantMgtUtil.java:151)
    at org.wso2.carbon.tenant.mgt.services.TenantMgtAdminService.notifyTenantAddition(TenantMgtAdminService.java:149)
    at org.wso2.carbon.tenant.mgt.services.TenantMgtAdminService.addTenant(TenantMgtAdminService.java:96)
```

The management console reports `Error in notifying tenant addition.` Because `TenantMgtAdminService.addTenant` persists the tenant before notifying listeners, the tenant row is already committed when keystore generation fails, leaving a registered tenant with no keystore and an inactive realm.

This is described in the Bouncy Castle 1.85 release notes ([`docs/releasenotes.html`](https://raw.githubusercontent.com/bcgit/bc-java/refs/heads/main/docs/releasenotes.html)):

> BCStyle and RFC4519Style now reject countryName (BCStyle.C / RFC4519Style.c) and, for BCStyle, jurisdictionCountry (JURISDICTION_C) attribute values whose length is not exactly 2 when constructing a new X500Name (via X500NameBuilder.addRDN or the X500Name(String) constructor). RFC 5280 sec. 4.1.2.4 / X.520 specify countryName as PrintableString (SIZE (2)) and CAB Forum Baseline Requirements 7.1.4.2.1 narrows it to a valid ISO 3166-1 alpha-2 code, so values such as "USA" now throw IllegalArgumentException at build time rather than encoding a non-spec value that downstream consumers would reject. Parsing of existing DER-encoded names containing a non-conforming country code is deliberately still permitted, so already-issued certificates in the wild remain readable (issue #2011).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Allow tenant keystore generation to succeed on Bouncy Castle 1.85 and later, without changing behaviour for tenants whose certificates were generated earlier.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Drop the country RDN from the generated DN:

```java
// before
String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None, C=None";
// after
String commonName = "CN=" + tenantDomain + ", OU=None, O=None, L=None";
```

`countryName` is optional in a subject DN, and the placeholder carried no information. Removing it is preferable to substituting an arbitrary two-letter code, which would be equally meaningless but would then appear in every tenant certificate.

Only the country attribute is affected by the new validation — `OU=None`, `O=None` and `L=None` are still accepted by Bouncy Castle 1.85, so they are left unchanged and the DN keeps its existing shape otherwise.

`commonName` is built once at line 170 and consumed by both provider branches (the FIPS branch at lines 173/176 and the regular branch at lines 188/190), so this single change covers both paths.

As noted in the release notes above, parsing of already-encoded names containing a non-conforming country code is still permitted, so certificates issued before this change remain readable and existing tenants are unaffected.

## User stories
> Summary of user stories addressed by this change>

As an administrator, I can create a new tenant on a deployment running Bouncy Castle 1.85 or later.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed tenant creation failing with `Error in notifying tenant addition.` when running with Bouncy Castle 1.85 or later, caused by a non-conforming country attribute in the generated tenant certificate DN.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — the generated tenant certificate DN is an internal implementation detail and is not documented.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

N/A — this is an internal bug fix with no impact on certification exam content.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A

## Automation tests
 - Unit tests
   > Code coverage information

No new unit tests. The change is a one-line correction to a hardcoded DN string in a method that generates an RSA key pair and writes a keystore to the registry, which the existing unit test setup does not cover.

 - Integration tests
   > Details about the test cases and coverage

Verified manually against a product build; details under **Test environment**.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

None. The same DN is built on `master`, where the equivalent change is needed; that is not included here as the surrounding code differs.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

None required. Tenant keystores are generated only on tenant creation, and only when one does not already exist, so certificates issued before this change are never regenerated. Verified by upgrading an existing deployment in place: the pre-existing tenant kept its certificate and its JWKS key id unchanged.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Tested on WSO2 API Manager 4.7.0, macOS 15 (arm64), OpenJDK 21.0.9 (Temurin), H2.

Scenario, on a single deployment carried across the upgrade:

1. Created tenant `bcold.com` on Bouncy Castle 1.84, producing a certificate with the old DN (`CN=bcold.com, OU=None, O=None, L=None, C=None`).
2. Upgraded the same deployment to Bouncy Castle 1.85 with this change applied.
3. Existing tenant `bcold.com` — publisher and devportal returned `200`, JWKS key id unchanged, certificate not regenerated.
4. New tenant `bcnew.com` — created successfully, `Added the tenant 'bcnew.com [33]' by 'admin'`, no country code errors, publisher and devportal returned `200`, JWKS served an RS256 key, certificate subject `CN=bcnew.com, OU=None, O=None, L=None`.
5. Super tenant — token issuance, gateway invocation and JWKS all returned `200`.

Without this change, step 4 fails with the exception quoted above.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

The Bouncy Castle 1.85 release notes ([`docs/releasenotes.html`](https://raw.githubusercontent.com/bcgit/bc-java/refs/heads/main/docs/releasenotes.html)) describe the new `countryName` validation and its rationale (RFC 5280 sec. 4.1.2.4 and X.520 specify `countryName` as `PrintableString (SIZE (2))`).

The behaviour was isolated to Bouncy Castle alone by constructing `new X500Name(dn)` directly against the 1.84 and 1.85 jars, with no product code involved:

| DN | 1.84 | 1.85 |
|---|---|---|
| `CN=x, OU=None, O=None, L=None, C=None` | accepted | rejected |
| `CN=x, OU=None, O=None, L=None, C=US` | accepted | accepted |
| `CN=x, OU=None, O=None, L=None` | accepted | accepted |
| `CN=x, C=None` | accepted | rejected |
| `CN=x, OU=None` | accepted | accepted |

This confirmed that only the country attribute is validated, so the fix could be limited to that single RDN.
