### PR TITLE
Bump org.json.wso2 dependency to 3.0.0.wso2v9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1042,7 +1042,7 @@
         <opensaml2.wso2.version>3.3.1.wso2v1</opensaml2.wso2.version>
 
         <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
-        <orbit.version.json>3.0.0.wso2v4</orbit.version.json>
+        <orbit.version.json>3.0.0.wso2v9</orbit.version.json>
 
         <project.scm.id>my-scm-server</project.scm.id>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>


### PR DESCRIPTION
## Summary
- Bumps the `orbit.version.json` property from `3.0.0.wso2v4` to `3.0.0.wso2v9`.

## Related
Related to wso2/product-is#28299

## Test plan
- [x] `mvn clean install -DskipTests` on the full reactor — build succeeds against the new version.
- [x] Verified in a locally-assembled `product-is` distribution that the resulting pack ships `json_3.0.0.wso2v9.jar`.